### PR TITLE
[Feat] 이벤트/메모 UI 개선

### DIFF
--- a/src/features/event/components/EventTab.tsx
+++ b/src/features/event/components/EventTab.tsx
@@ -1,4 +1,4 @@
-import type { StockEvent } from '../types/event.types';
+import type { StockEvent } from "../types/event.types";
 
 interface EventTabProps {
   event: StockEvent;
@@ -6,38 +6,57 @@ interface EventTabProps {
 }
 
 export default function EventTab({ event, onScrap }: EventTabProps) {
-  const { eventId, stockName, eventType, occurredAt, changeRate, priceBefore, priceAfter, aiSummary, relatedNews, isScrapped } = event;
+  const {
+    eventId,
+    stockName,
+    eventType,
+    occurredAt,
+    changeRate,
+    priceBefore,
+    priceAfter,
+    aiSummary,
+    relatedNews,
+    isScrapped,
+  } = event;
 
-  const isSurge = eventType === 'SURGE';
-  const sign = isSurge ? '+' : '-';
-  const rateColor = isSurge ? '#dc2626' : '#1d4ed8';
+  const isSurge = eventType === "SURGE";
+  const sign = isSurge ? "+" : "-";
+  const rateColor = isSurge ? "#e03131" : "#1971c2";
 
   const date = new Date(occurredAt);
-  const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
-  const dateLabel = `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')} (${weekdays[date.getDay()]})`;
+  const weekdays = ["일", "월", "화", "수", "목", "금", "토"];
+  const dateLabel = `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, "0")}.${String(date.getDate()).padStart(2, "0")} (${weekdays[date.getDay()]})`;
 
   return (
-    <div className="relative flex-1 min-h-0">
-      <div className="absolute inset-0 overflow-y-auto scrollbar-subtle pb-22 px-4">
-
+    <div className="flex flex-col flex-1 min-h-0">
+      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-subtle px-4" style={{ scrollbarGutter: 'stable' }}>
         {/* 이벤트 헤더 카드 */}
         <div
           className="mt-3 mb-2.5 rounded-[14px] p-4"
-          style={isSurge
-            ? { background: '#FFFBF7', border: '1px solid #F3E3CC' }
-            : { background: '#F5F9FF', border: '1px solid #DBEAFE' }
-          }
+          style={{ background: "#fff", border: "1px solid #e5e7eb" }}
         >
           <div className="flex justify-between items-center mb-1.5">
             <span className="text-xs text-[#9ca3af]">{dateLabel}</span>
-            <span className="text-xs font-bold" style={{ color: rateColor }}>
-              {isSurge ? '급등' : '급락'}
+            <span
+              className="text-[11px] font-bold px-2 py-0.5 rounded-[4px]"
+              style={isSurge
+                ? { color: "#e03131", background: "#FFF0F0" }
+                : { color: "#1971c2", background: "#EFF6FF" }
+              }
+            >
+              {isSurge ? "급등" : "급락"}
             </span>
           </div>
           <div className="mb-1">
-            <span className="font-bold text-[20px] md:text-[22px] text-text-primary">{stockName} </span>
-            <span className="font-bold text-[20px] md:text-[22px]" style={{ color: rateColor }}>
-              {sign}{changeRate}%
+            <span className="font-bold text-[20px] md:text-[22px] text-text-primary">
+              {stockName}{" "}
+            </span>
+            <span
+              className="font-bold text-[20px] md:text-[22px]"
+              style={{ color: rateColor }}
+            >
+              {sign}
+              {changeRate}%
             </span>
           </div>
           <p className="text-[13px] text-[#9ca3af]">
@@ -46,36 +65,76 @@ export default function EventTab({ event, onScrap }: EventTabProps) {
         </div>
 
         {/* AI 요약 */}
-        <div className="rounded-[10px] p-3.5 mb-4" style={{ background: '#fff', border: '1px solid #e5e7eb' }}>
+        <div
+          className="rounded-[10px] p-3.5 mb-4"
+          style={{ background: "#fff", border: "1px solid #e5e7eb" }}
+        >
           <div className="flex items-center gap-1.5 mb-2">
             <span className="w-2 h-2 rounded-full bg-blue-600 shrink-0" />
-            <span className="text-xs font-bold text-blue-600">AI 요약 · 참고 정보</span>
+            <span className="text-xs font-bold text-blue-600">
+              AI 요약 · 참고 정보
+            </span>
           </div>
-          <p className="text-[13px] text-[#374151] leading-[1.7] mb-2.5">{aiSummary}</p>
+          <p className="text-[13px] text-[#374151] leading-[1.7] mb-2.5">
+            {aiSummary}
+          </p>
           <div className="flex items-center gap-1">
-            <svg width="12" height="12" fill="none" stroke="#9ca3af" strokeWidth="1.5" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            <svg
+              width="12"
+              height="12"
+              fill="none"
+              stroke="#9ca3af"
+              strokeWidth="1.5"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 9v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
             </svg>
-            <span className="text-[11px] text-[#9ca3af]">실제 원인 단정이 아닌 참고 정보입니다</span>
+            <span className="text-[11px] text-[#9ca3af]">
+              실제 원인 단정이 아닌 참고 정보입니다
+            </span>
           </div>
         </div>
 
         {/* 관련 뉴스 */}
         <div>
-          <p className="font-semibold text-sm text-[#374151] mb-2.5">관련 뉴스</p>
+          <p className="font-semibold text-sm text-[#374151] mb-2.5">
+            관련 뉴스
+          </p>
           <div className="space-y-2.5">
             {relatedNews.map((news) => (
               <div
                 key={news.newsId}
-                onClick={() => window.open(news.url, '_blank', 'width=800,height=600,noopener,noreferrer')}
+                onClick={() =>
+                  window.open(
+                    news.url,
+                    "_blank",
+                    "width=800,height=600,noopener,noreferrer",
+                  )
+                }
                 className="block bg-white rounded-[10px] p-[12px_14px] active:bg-bg-subtle md:hover:bg-bg-subtle transition-colors cursor-pointer"
-                style={{ border: '1px solid #e5e7eb' }}
+                style={{ border: "1px solid #e5e7eb" }}
               >
-                <p className="font-bold text-sm text-text-primary leading-[1.4] mb-1.5">{news.title}</p>
-                <p className="text-[13px] text-[#6b7280] leading-[1.6] mb-2">{news.body}</p>
+                <p className="font-bold text-sm text-text-primary leading-[1.4] mb-1.5">
+                  {news.title}
+                </p>
+                <p className="text-[13px] text-[#6b7280] leading-[1.6] mb-2">
+                  {news.body}
+                </p>
                 <div className="flex justify-between items-center">
                   <span className="text-[11px] text-[#9ca3af]">
-                    {news.source} · {new Date(news.publishedAt).toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' }).replace(/\. /g, '.').slice(0, -1)}
+                    {news.source} ·{" "}
+                    {new Date(news.publishedAt)
+                      .toLocaleDateString("ko-KR", {
+                        year: "numeric",
+                        month: "2-digit",
+                        day: "2-digit",
+                      })
+                      .replace(/\. /g, ".")
+                      .slice(0, -1)}
                   </span>
                   <span className="text-[11px] text-[#4b5563] bg-[#f3f4f6] px-2 py-0.5 rounded-full">
                     {news.tag}
@@ -86,15 +145,14 @@ export default function EventTab({ event, onScrap }: EventTabProps) {
           </div>
           <div className="h-4" />
         </div>
-
       </div>
 
       {/* 스크랩 버튼 고정 하단 */}
-      <div className="absolute bottom-0 left-0 right-0 px-4 pt-3 pb-5 md:pb-6 border-t border-border bg-white">
+      <div className="shrink-0 px-4 pt-3 pb-5 md:pb-6 border-t border-border bg-white">
         <button
           onClick={() => onScrap?.(eventId, isScrapped)}
           className="w-full py-3 md:py-3.25 rounded-[10px] text-[15px] font-bold text-white transition-colors active:opacity-80"
-          style={{ background: isScrapped ? '#013d7d' : '#014d9d' }}
+          style={{ background: isScrapped ? "#013d7d" : "#014d9d" }}
         >
           스크랩
         </button>

--- a/src/features/event/components/MemoTab.tsx
+++ b/src/features/event/components/MemoTab.tsx
@@ -1,17 +1,32 @@
 import { useState } from 'react';
-import type { StockMemo } from '../types/event.types';
+import type { EventType, StockMemo } from '../types/event.types';
+
+interface EventInfo {
+  eventType: EventType;
+  stockName: string;
+  changeRate: number;
+}
 
 interface MemoTabProps {
   memos: StockMemo[];
+  eventInfo?: EventInfo;
   onSave?: (text: string) => void;
   onDelete?: (memoId: number) => void;
 }
 
 const MAX_LENGTH = 300;
 
+function SendIcon() {
+  return (
+    <svg width="17" height="17" fill="none" stroke="#fff" strokeWidth="2" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+    </svg>
+  );
+}
+
 function TrashIcon() {
   return (
-    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#9ca3af" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#9ca3af" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block' }}>
       <polyline points="3 6 5 6 21 6" />
       <path d="M19 6l-1 14H6L5 6" />
       <path d="M10 11v6M14 11v6" />
@@ -20,25 +35,7 @@ function TrashIcon() {
   );
 }
 
-function EditIcon() {
-  return (
-    <svg width="17" height="17" fill="none" stroke="#fff" strokeWidth="2" viewBox="0 0 24 24">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-    </svg>
-  );
-}
-
-function groupByYear(memos: StockMemo[]) {
-  const groups: Record<string, StockMemo[]> = {};
-  memos.forEach((m) => {
-    const year = m.date.split('.')[0]?.length === 2 ? '2026' : m.date.split('.')[0] ?? '2026';
-    if (!groups[year]) groups[year] = [];
-    groups[year].push(m);
-  });
-  return groups;
-}
-
-export default function MemoTab({ memos, onSave, onDelete }: MemoTabProps) {
+export default function MemoTab({ memos, eventInfo, onSave, onDelete }: MemoTabProps) {
   const [text, setText] = useState('');
   const [confirmId, setConfirmId] = useState<number | null>(null);
 
@@ -53,131 +50,128 @@ export default function MemoTab({ memos, onSave, onDelete }: MemoTabProps) {
     setText('');
   };
 
-  const groups = groupByYear(memos);
+  const info = eventInfo ?? (memos[0] ? { eventType: memos[0].eventType, stockName: memos[0].stockName, changeRate: memos[0].changeRate } : null);
+  const isSurge = info?.eventType === 'SURGE';
+  const badgeStyle = isSurge
+    ? { color: '#e03131', background: '#FFF0F0' }
+    : { color: '#1971c2', background: '#EFF6FF' };
+  const sign = isSurge ? '+' : '-';
+
+  const groupedByYear = memos.reduce<Record<string, StockMemo[]>>((acc, memo) => {
+    const year = memo.date.split('.')[0]?.length === 2 ? '2026' : (memo.date.split('.')[0] ?? '2026');
+    if (!acc[year]) acc[year] = [];
+    acc[year].push(memo);
+    return acc;
+  }, {});
 
   return (
-    <div className="relative flex-1 min-h-0">
+    <div className="flex flex-col flex-1 min-h-0">
 
-      {/* 삭제 확인 토스트 */}
+      {/* 외부 클릭 시 토스트 닫기 */}
       {confirmId !== null && (
-        <div className="absolute top-3 right-4 z-50 flex items-center gap-3 px-4 py-3 bg-white rounded-xl shadow-md" style={{ border: '1px solid #e5e7eb' }}>
-          <span className="text-sm text-text-primary font-medium">메모를 삭제할까요?</span>
-          <div className="flex gap-2">
-            <button
-              onClick={() => setConfirmId(null)}
-              className="px-3 py-1.5 rounded-[8px] text-xs font-semibold text-[#6b7280] bg-[#f3f4f6] hover:bg-[#e5e7eb] transition-colors"
-            >
-              취소
-            </button>
-            <button
-              onClick={handleConfirm}
-              className="px-3 py-1.5 rounded-[8px] text-xs font-semibold text-white transition-colors"
-              style={{ background: '#014d9d' }}
-            >
-              삭제
-            </button>
+        <div className="absolute inset-0 z-20" onClick={() => setConfirmId(null)} />
+      )}
+
+      {/* 이벤트 정보 고정 상단 */}
+      {info && (
+        <div className="shrink-0 px-4 py-3 bg-white border-b border-[#f3f4f6]">
+          <div className="flex items-center gap-2">
+            <span className="text-[11px] font-bold px-2 py-0.5" style={{ ...badgeStyle, borderRadius: 4 }}>
+              {isSurge ? '급등' : '급락'}
+            </span>
+            <span className="text-[13px] font-semibold text-text-primary">
+              {info?.stockName} {sign}{Math.abs(info?.changeRate ?? 0)}%
+            </span>
           </div>
         </div>
       )}
 
       {/* 메모 목록 */}
-      <div className="absolute inset-0 overflow-y-auto scrollbar-subtle pb-20 md:pb-43">
-        {memos.length === 0 && (
-          <p className="text-center text-sm text-[#9ca3af] mt-10">아직 작성한 메모가 없어요</p>
-        )}
-
-        {Object.entries(groups).map(([year, list]) => (
-          <div key={year}>
-            <p className="md:hidden px-4 pt-2.5 pb-1 text-[13px] text-[#9ca3af] font-medium">{year}</p>
-            {list.map((memo) => {
-              const isSurge = memo.eventType === 'SURGE';
-              const sign = isSurge ? '+' : '-';
-              const badgeStyle = isSurge
-                ? { color: '#ef4444', background: '#FFF0F0' }
-                : { color: '#3b82f6', background: '#EFF6FF' };
-
-              return (
-                <div
-                  key={memo.memoId}
-                  className="mx-4 mb-2.5 bg-white rounded-[14px] p-[14px_16px] md:rounded-[10px]"
-                  style={{ border: '1px solid #eeeeee' }}
-                >
-                  <div className="flex items-center justify-between mb-2">
-                    <div className="flex items-center gap-2">
-                      <span className="text-[11px] font-bold px-2 py-0.5" style={{ ...badgeStyle, borderRadius: 4 }}>
-                        {isSurge ? '급등' : '급락'}
-                      </span>
-                      <span className="text-[13px] font-semibold text-text-primary">
-                        {memo.stockName} {sign}{Math.abs(memo.changeRate)}%
-                      </span>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <span className="text-xs leading-none text-[#9ca3af]">{memo.date}</span>
-                      <button
-                        onClick={() => setConfirmId(memo.memoId)}
-                        className="flex items-center justify-center hover:opacity-60 transition-opacity"
-                      >
-                        <TrashIcon />
-                      </button>
-                    </div>
+      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-subtle" style={{ scrollbarGutter: 'stable' }}>
+        <div className="px-4 pt-3">
+          {memos.length === 0 && (
+            <p className="text-center text-sm text-[#9ca3af] mt-10">아직 작성한 메모가 없어요</p>
+          )}
+          {memos.length > 0 && (
+            <div>
+              {Object.entries(groupedByYear).map(([year, list]) => (
+                <div key={year}>
+                  <p className="pt-1 pb-2 text-[12px] text-[#9ca3af] font-medium">{year}</p>
+                  <div className="space-y-2.5 mb-3">
+                    {list.map((memo) => (
+                      <div key={memo.memoId} className="bg-white rounded-[14px] p-[14px_16px]" style={{ border: '1px solid #eeeeee' }}>
+                        <div className="flex items-center justify-between mb-2">
+                          <span className="text-xs leading-none text-[#9ca3af]">{memo.date}</span>
+                          <div className="relative flex items-center">
+                            {confirmId === memo.memoId && (
+                              <div className="absolute right-6 z-30 flex items-center gap-2 px-2.5 py-1.5 rounded-lg shadow-sm whitespace-nowrap" style={{ background: '#fff', border: '1px solid #e5e7eb' }}>
+                                <span className="text-[11px] text-text-primary font-medium">삭제할까요?</span>
+                                <button
+                                  onClick={handleConfirm}
+                                  className="text-[11px] font-semibold hover:opacity-70 transition-opacity"
+                                  style={{ color: '#e03131' }}
+                                >
+                                  확인
+                                </button>
+                              </div>
+                            )}
+                            <button onClick={() => setConfirmId(memo.memoId === confirmId ? null : memo.memoId)} className="flex items-center justify-center hover:opacity-60 transition-opacity">
+                              <TrashIcon />
+                            </button>
+                          </div>
+                        </div>
+                        <p className="text-[13px] text-[#374151] leading-[1.65] break-all">{memo.text}</p>
+                      </div>
+                    ))}
                   </div>
-                  <p className="text-[13px] text-[#374151] leading-[1.65]">{memo.text}</p>
                 </div>
-              );
-            })}
-          </div>
-        ))}
-
-        <div className="hidden md:block text-right px-5 py-0.5 text-[11px] text-[#9ca3af]">
-          {text.length} / {MAX_LENGTH}
+              ))}
+            </div>
+          )}
         </div>
       </div>
 
-      {/* 입력 영역 — 항상 하단 고정 */}
-      <div className="absolute bottom-0 left-0 right-0 border-t border-border bg-white">
-        {/* 모바일 */}
-        <div className="md:hidden relative px-4 pt-2.5 pb-5">
+      {/* 모바일: input + 전송 버튼 나란히 */}
+      <div className="md:hidden shrink-0 border-t border-border bg-white px-4 pt-2.5 pb-5">
+        <div className="flex items-center gap-2">
           <input
             type="text"
             value={text}
             onChange={(e) => setText(e.target.value.slice(0, MAX_LENGTH))}
             placeholder="이 이벤트에 대한 메모를 남겨보세요"
-            className="w-full bg-[#f3f4f6] rounded-xl px-3.5 py-3 pr-14 text-sm text-[#374151] outline-none placeholder:text-[#9ca3af]"
+            className="flex-1 bg-[#f3f4f6] rounded-xl px-3.5 py-3 text-sm text-[#374151] outline-none placeholder:text-[#9ca3af]"
           />
           <button
             onClick={handleSave}
             disabled={!text.trim()}
-            className="absolute right-7 top-1/2 -translate-y-1/2 w-9.5 h-9.5 rounded-full bg-blue-600 flex items-center justify-center disabled:opacity-40 transition-opacity active:opacity-60"
+            className="w-10 h-10 rounded-full bg-blue-600 flex items-center justify-center shrink-0 disabled:opacity-40 transition-opacity active:opacity-60"
           >
-            <EditIcon />
+            <SendIcon />
           </button>
         </div>
+      </div>
 
-        {/* 데스크톱 */}
-        <div className="hidden md:block">
-          <div className="mx-5 mt-3">
-            <textarea
-              value={text}
-              onChange={(e) => setText(e.target.value.slice(0, MAX_LENGTH))}
-              placeholder="이 이벤트에 대한 메모를 남겨보세요"
-              className="w-full rounded-[10px] px-3.5 py-3 text-[13px] text-[#374151] leading-[1.7] resize-none outline-none bg-bg-subtle placeholder:text-[#9ca3af]"
-              style={{ border: '1px solid #e5e7eb', height: 100 }}
-            />
-            <div className="text-right text-[11px] text-[#9ca3af] mt-1 mb-2">
-              {text.length} / {MAX_LENGTH}
-            </div>
-          </div>
-          <div className="px-5 pb-4">
-            <button
-              onClick={handleSave}
-              disabled={!text.trim()}
-              className="w-full py-3.25 rounded-[10px] text-[15px] font-bold text-white transition-colors disabled:opacity-40"
-              style={{ background: '#014d9d' }}
-            >
-              메모 저장
-            </button>
-          </div>
+      {/* 데스크톱: 메모 작성 + 저장 버튼 */}
+      <div className="hidden md:block shrink-0 px-4 pt-3 pb-5 border-t border-border bg-white">
+        <p className="text-[13px] font-semibold text-[#374151] mb-2">메모 작성</p>
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value.slice(0, MAX_LENGTH))}
+          placeholder="이 이벤트에 대한 메모를 남겨보세요"
+          className="w-full rounded-[10px] px-3.5 py-3 text-[13px] text-[#374151] leading-[1.7] resize-none outline-none bg-bg-subtle placeholder:text-[#9ca3af]"
+          style={{ border: '1px solid #e5e7eb', height: 100 }}
+        />
+        <div className="text-right text-[11px] text-[#9ca3af] mt-1 mb-3">
+          {text.length} / {MAX_LENGTH}
         </div>
+        <button
+          onClick={handleSave}
+          disabled={!text.trim()}
+          className="w-full py-3 rounded-[10px] text-[15px] font-bold text-white transition-colors disabled:opacity-40"
+          style={{ background: '#014d9d' }}
+        >
+          메모 저장
+        </button>
       </div>
     </div>
   );

--- a/src/pages/Chart/components/StockDetailMain.tsx
+++ b/src/pages/Chart/components/StockDetailMain.tsx
@@ -2,7 +2,12 @@ import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { ROUTES } from "@/shared/constants/routes";
 import type { ChartPin, StockDetailMainProps } from "../types";
-import { useChartPeriod, useOhlcData, useOhlcSummary, useStockInfo } from "../hook";
+import {
+  useChartPeriod,
+  useOhlcData,
+  useOhlcSummary,
+  useStockInfo,
+} from "../hook";
 import { CandlestickChart } from "./CandlestickChart";
 import { StockInfoBar } from "./StockInfoBar";
 import { PeriodTabs } from "./PeriodTabs";
@@ -26,14 +31,37 @@ const MOCK_EVENT: StockEvent = {
   aiSummary:
     "이 구간에서는 엔비디아 GTC 컨퍼런스 이후 HBM3E 공급 기대감이 급격히 확대되었습니다. 삼성전자의 AI 칩 납품 재개 가능성이 보도되며 외국인 매수세가 집중된 것으로 확인됩니다.",
   relatedNews: [
-    { newsId: 1, title: "외국인, 삼성전자 3일 연속 순매수 2조원 돌파", body: "외국인 투자자들이 삼성전자를 3거래일 연속 순매수하며 코스피 상승을 이끌었다.", source: "연합인포맥스", publishedAt: "2025-11-26T10:00:00", url: "#", tag: "외국인" },
-    { newsId: 2, title: "삼성전자 HBM3E 납품 재개 기대감 확산", body: "엔비디아향 HBM3E 공급 재개 가능성이 제기되며 반도체 섹터 전반에 매수세가 유입됐다.", source: "한국경제", publishedAt: "2025-11-26T11:00:00", url: "#", tag: "반도체" },
+    {
+      newsId: 1,
+      title: "외국인, 삼성전자 3일 연속 순매수 2조원 돌파",
+      body: "외국인 투자자들이 삼성전자를 3거래일 연속 순매수하며 코스피 상승을 이끌었다.",
+      source: "연합인포맥스",
+      publishedAt: "2025-11-26T10:00:00",
+      url: "#",
+      tag: "외국인",
+    },
+    {
+      newsId: 2,
+      title: "삼성전자 HBM3E 납품 재개 기대감 확산",
+      body: "엔비디아향 HBM3E 공급 재개 가능성이 제기되며 반도체 섹터 전반에 매수세가 유입됐다.",
+      source: "한국경제",
+      publishedAt: "2025-11-26T11:00:00",
+      url: "#",
+      tag: "반도체",
+    },
   ],
   isScrapped: false,
 };
 
 const INITIAL_MEMOS: StockMemo[] = [
-  { memoId: 1, eventType: "SURGE", stockName: "삼성전자", changeRate: 19.47, date: "03.16", text: "HBM 납품 기대감으로 외국인 매수세가 강하게 붙은 구간." },
+  {
+    memoId: 1,
+    eventType: "SURGE",
+    stockName: "삼성전자",
+    changeRate: 19.47,
+    date: "03.16",
+    text: "HBM 납품 기대감으로 외국인 매수세가 강하게 붙은 구간.",
+  },
 ];
 
 /** 목업 `MOCK_PINS` 등 — 초록 이벤트 핀 (`#059669`) */
@@ -60,12 +88,24 @@ export function StockDetailMain({
 }: StockDetailMainAllProps) {
   const navigate = useNavigate();
   const { activePeriod, setActivePeriod } = useChartPeriod("월");
-  const [mobileTab, setMobileTab] = useState<"차트" | "이벤트" | "메모">("차트");
+  const [mobileTab, setMobileTab] = useState<"차트" | "이벤트" | "메모">(
+    "차트",
+  );
   const [memos, setMemos] = useState<StockMemo[]>(INITIAL_MEMOS);
 
   const handleMemoSave = (text: string) => {
     setMemos((prev) => [
-      { memoId: Date.now(), eventType: "SURGE", stockName: "삼성전자", changeRate: 17.2, date: new Date().toLocaleDateString("ko-KR", { month: "2-digit", day: "2-digit" }).replace(/\. /g, ".").slice(0, -1), text },
+      {
+        memoId: Date.now(),
+        eventType: "SURGE",
+        stockName: "삼성전자",
+        changeRate: 17.2,
+        date: new Date()
+          .toLocaleDateString("ko-KR", { month: "2-digit", day: "2-digit" })
+          .replace(/\. /g, ".")
+          .slice(0, -1),
+        text,
+      },
       ...prev,
     ]);
   };
@@ -148,7 +188,9 @@ export function StockDetailMain({
                   </div>
                 ))
               ) : (
-                <div className="text-xs text-[#9ca3af]">이벤트 핀 데이터가 없습니다.</div>
+                <div className="text-xs text-[#9ca3af]">
+                  이벤트 핀 데이터가 없습니다.
+                </div>
               )}
             </div>
 
@@ -160,17 +202,33 @@ export function StockDetailMain({
             </div>
 
             <div className="min-h-0 flex-1 px-1 pb-2 pt-2">
-              <CandlestickChart bars={bars} pins={pins} onPinClick={handlePinClick} />
+              <CandlestickChart
+                bars={bars}
+                pins={pins}
+                onPinClick={handlePinClick}
+              />
             </div>
           </>
         )}
 
         {mobileTab === "이벤트" && (
-          <EventTab event={MOCK_EVENT} onScrap={(id, s) => console.log(id, s)} />
+          <EventTab
+            event={MOCK_EVENT}
+            onScrap={(id, s) => console.log(id, s)}
+          />
         )}
 
         {mobileTab === "메모" && (
-          <MemoTab memos={memos} onSave={handleMemoSave} onDelete={handleMemoDelete} />
+          <MemoTab
+            memos={memos}
+            eventInfo={{
+              eventType: MOCK_EVENT.eventType,
+              stockName: MOCK_EVENT.stockName,
+              changeRate: MOCK_EVENT.changeRate,
+            }}
+            onSave={handleMemoSave}
+            onDelete={handleMemoDelete}
+          />
         )}
       </div>
 
@@ -190,7 +248,11 @@ export function StockDetailMain({
         </div>
 
         <main className="min-h-0 flex-1 overflow-hidden border-t border-[#eff1f8] bg-white">
-          <CandlestickChart bars={bars} pins={pins} onPinClick={handlePinClick} />
+          <CandlestickChart
+            bars={bars}
+            pins={pins}
+            onPinClick={handlePinClick}
+          />
         </main>
 
         <div className="shrink-0 border-t border-[#eff1f8] bg-[#f9fafc]">

--- a/src/pages/StockDetail/index.tsx
+++ b/src/pages/StockDetail/index.tsx
@@ -52,7 +52,7 @@ export default function StockDetailPage() {
     <div className="flex flex-col flex-1 min-h-0">
       <TabBar tabs={TABS} value={tab} onChange={setTab} />
       {tab === 'event' && <EventTab event={mockEvent} onScrap={(id, s) => console.log(id, s)} />}
-      {tab === 'memo' && <MemoTab memos={memos} onSave={handleSave} onDelete={handleDelete} />}
+      {tab === 'memo' && <MemoTab memos={memos} eventInfo={{ eventType: mockEvent.eventType, stockName: mockEvent.stockName, changeRate: mockEvent.changeRate }} onSave={handleSave} onDelete={handleDelete} />}
     </div>
   );
 }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -25,6 +25,7 @@
     "noUncheckedSideEffectImports": true,
 
     /* Path aliases */
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  optimizeDeps: {
+    include: ["firebase/app", "firebase/messaging"],
+  },
   server: {
     proxy: {
       '/auth': {


### PR DESCRIPTION
## #️⃣ Issue Number
<!--- ex) #이슈번호, #이슈번호 -->
- Closes #45 
## 📝 변경사항
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 🎯 핵심 변경 사항 (Key Changes)
- [ ] EventTab UI 개선: 이벤트 헤더 카드 배경색을 흰색으로 통일하고, 급등/급락 배지를 배경색 있는 pill 스타일로 변경. 색상을 StockInfoBar와 통일(#e03131 / #1971c2)
- [ ] EventTab 레이아웃 리팩토링: absolute 포지셔닝 → flex column 구조로 변경하여 스크롤바 잘림 현상 해소 (scrollbarGutter: stable 적용)
- [ ] MemoTab 전면 개선: 이벤트 정보(eventInfo prop)를 상단에 한 번만 고정 표시하고, 메모 카드에서 중복 표시 제거. 연도별 그룹핑 유지
- [ ] MemoTab 레이아웃 리팩토링: EventTab과 동일하게 absolute → flex column 구조로 변경
- [ ] MemoTab 삭제 확인 UX 개선: 상단 토스트 → 휴지통 아이콘 옆 인라인 미니 팝업으로 변경
- [ ] MemoTab 모바일 입력 UI 개선: 입력창 내부 버튼 → 입력창 + 원형 전송 버튼 나란히 배치
- [ ] 메모 긴 텍스트 처리: break-all 추가로 공백 없는 긴 텍스트도 카드 내에서 줄바꿈
- [ ] eventInfo 누락 버그 수정: StockDetailPage에서 MemoTab에 eventInfo prop을 전달하지 않아 메모 없을 때 이벤트 정보가 사라지는 문제 수정
### 🔍 주안점 & 리뷰 포인트
- MemoTab의 eventInfo prop이 없을 경우 memos[0]에서 폴백하는 로직 (const info = eventInfo ?? ...): eventInfo를 항상 명시적으로 내려주는 방향이 바람직하므로 추후 필수 prop으로 변경 고려
- flex column 레이아웃 구조: flex-1 min-h-0가 부모 체인에 올바르게 설정되어 있어야 스크롤이 정상 동작합니다
### 🖼️ 스크린샷 / 테스트 결과 (선택 사항)
<!--
  (Optional)
  작업 결과 만들거나 변경된 화면 스크린샷
  테스트 수행 결과 스크린샷
-->
---

## 🛠️ PR 유형
- [ ] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## 🧪 영향 범위 및 테스트 (Impact & Tests)
<!--
  (Optional)
  작업에 의해 영향을 받은 모듈/컴포넌트 설명
  수행한 테스트 설명
-->
### **영향을 받는 모듈/컴포넌트:** 
<!--
  (예: `core-api`, `domain-blog`)
-->
features/event/components/EventTab, features/event/components/MemoTab, pages/StockDetail, pages/Chart/components/StockDetailMain
### **테스트 방법:**
- [ ] 단위 테스트 (JUnit/Jest)
- [ ] 통합 테스트
- [ ] 수동 API 테스트 (Postman/Swagger)

## ✅ PR Checklist
- [ ] 커밋 메시지 컨벤션을 준수했습니다.
- [ ] 불필요한 로그나 주석을 제거했습니다.
- [ ] 관련 이슈를 연결했습니다.
