### PR TITLE
[Feat] 관심 종목 연동

### DIFF
--- a/src/features/stock/api/interestStockApi.ts
+++ b/src/features/stock/api/interestStockApi.ts
@@ -1,0 +1,36 @@
+import apiClient from '@/shared/api/axios';
+import type { InterestStockItemDto } from '@/features/stock/types';
+
+type ApiEnvelope<T> = {
+  isSuccess: boolean;
+  responseCode: number;
+  responseMessage: string;
+  result: T;
+};
+
+/**
+ * 관심 종목 목록 — GET /api/me/interest-stocks
+ */
+export async function fetchInterestStocks(): Promise<InterestStockItemDto[]> {
+  const { data } = await apiClient.get<ApiEnvelope<{ items: InterestStockItemDto[] }>>(
+    '/api/me/interest-stocks'
+  );
+  const items = data?.result?.items;
+  return Array.isArray(items) ? items : [];
+}
+
+/**
+ * 관심 종목 추가 — POST /api/me/interest-stocks
+ */
+export async function addInterestStock(stockId: number): Promise<void> {
+  await apiClient.post<ApiEnvelope<Record<string, unknown>>>('/api/me/interest-stocks', {
+    stockId,
+  });
+}
+
+/**
+ * 관심 종목 제거 — DELETE /api/me/interest-stocks/{stockId}
+ */
+export async function removeInterestStock(stockId: number): Promise<void> {
+  await apiClient.delete<ApiEnvelope<Record<string, unknown>>>(`/api/me/interest-stocks/${stockId}`);
+}

--- a/src/features/stock/hooks/useInterestStocks.ts
+++ b/src/features/stock/hooks/useInterestStocks.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAuth } from '@/features/auth/context/AuthContext';
+import {
+  addInterestStock,
+  fetchInterestStocks,
+  removeInterestStock,
+} from '@/features/stock/api/interestStockApi';
+
+export const INTEREST_STOCKS_QUERY_KEY = ['interest-stocks'] as const;
+
+export function useInterestStocksQuery() {
+  const { isLoggedIn } = useAuth();
+
+  return useQuery({
+    queryKey: INTEREST_STOCKS_QUERY_KEY,
+    queryFn: fetchInterestStocks,
+    enabled: isLoggedIn,
+  });
+}
+
+export function useAddInterestStockMutation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: addInterestStock,
+    onSuccess: () => qc.invalidateQueries({ queryKey: INTEREST_STOCKS_QUERY_KEY }),
+  });
+}
+
+export function useRemoveInterestStockMutation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: removeInterestStock,
+    onSuccess: () => qc.invalidateQueries({ queryKey: INTEREST_STOCKS_QUERY_KEY }),
+  });
+}

--- a/src/features/stock/types/index.ts
+++ b/src/features/stock/types/index.ts
@@ -2,6 +2,7 @@ export type {
   ApiEnvelope,
   CursorPageDto,
   HomeStockItemDto,
+  InterestStockItemDto,
   StockChangeDirection,
   StockChartPeriod,
   StockEventType,

--- a/src/features/stock/types/stock.types.ts
+++ b/src/features/stock/types/stock.types.ts
@@ -8,6 +8,18 @@ export type StockChangeDirection = 'UP' | 'DOWN' | 'FLAT';
 
 export type StockEventType = 'SURGE' | 'DROP';
 
+/** GET /api/me/interest-stocks — result.items[] */
+export interface InterestStockItemDto {
+  stockId: number;
+  ticker: string;
+  name: string;
+  market: string;
+  logoUrl?: string | null;
+  currentPrice: number;
+  changeRate: number;
+  changeDirection: StockChangeDirection;
+}
+
 export interface StockListParams {
   market?: StockMarket;
   sort?: StockSort;

--- a/src/index.css
+++ b/src/index.css
@@ -254,6 +254,12 @@ body {
   box-shadow: 0 8px 40px rgba(0, 0, 0, 0.13);
 }
 
+/* 데스크톱: 헤더 딤 위에만 표시(포털) — 위치는 인라인 */
+.search-dropdown--portal {
+  position: fixed;
+  z-index: 201;
+}
+
 /* 인기 검색 순위: 홈 종목 리스트와 동일하게 body(Pretendard) 상속 + 굵기 유지 */
 .search-popular-rank {
   flex-shrink: 0;

--- a/src/pages/Chart/components/StockDetailMain.tsx
+++ b/src/pages/Chart/components/StockDetailMain.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router";
+import LoginModal from "@/features/auth/components/LoginModal";
+import { useAuth } from "@/features/auth/context/AuthContext";
 import { fetchStockSearch } from "@/features/stock/api";
+import { useInterestStocksQuery } from "@/features/stock/hooks/useInterestStocks";
 import { ROUTES } from "@/shared/constants/routes";
 import type { OhlcBar, PeriodTab, StockDetailMainProps } from "../types";
 import {
@@ -118,7 +121,10 @@ export function StockDetailMain({
   mobileMode = "stock-detail",
 }: StockDetailMainAllProps) {
   const navigate = useNavigate();
+  const { refreshAuth } = useAuth();
+  const [loginModalOpen, setLoginModalOpen] = useState(false);
   const { stockCode: stockCodeParam } = useParams<{ stockCode?: string }>();
+  const { data: interestItems = [] } = useInterestStocksQuery();
 
   const [resolvedTickerStockId, setResolvedTickerStockId] = useState<number | undefined>(
     undefined
@@ -163,6 +169,14 @@ export function StockDetailMain({
   const routeHasTicker = Boolean(stockCodeParam);
   const holdEmptyChart = Boolean(
     stockCodeParam && !stockId && !searchSettled
+  );
+
+  const isInterested = useMemo(
+    () =>
+      chartStockId != null &&
+      chartStockId > 0 &&
+      interestItems.some((i) => i.stockId === chartStockId),
+    [chartStockId, interestItems]
   );
 
   const { activePeriod, setActivePeriod } = useChartPeriod("일");
@@ -250,6 +264,7 @@ export function StockDetailMain({
   }, [bars]);
 
   return (
+    <>
     <div
       className={`flex min-h-0 flex-1 flex-col overflow-hidden bg-[#f4f6fb] ${className}`}
     >
@@ -258,8 +273,11 @@ export function StockDetailMain({
         <div className="shrink-0 bg-white px-4 py-2.5">
           <StockInfoBar
             stock={stock}
+            stockId={chartStockId}
+            isInterested={isInterested}
             onBack={() => navigate(ROUTES.HOME)}
             onAddWatchlist={() => {}}
+            onRequireLogin={() => setLoginModalOpen(true)}
           />
         </div>
 
@@ -354,8 +372,11 @@ export function StockDetailMain({
         <div className="shrink-0 bg-white px-5 py-2.5">
           <StockInfoBar
             stock={stock}
+            stockId={chartStockId}
+            isInterested={isInterested}
             onBack={() => navigate(ROUTES.HOME)}
             onAddWatchlist={() => {}}
+            onRequireLogin={() => setLoginModalOpen(true)}
           />
 
           <div className="mt-2.5 flex flex-wrap items-center justify-between gap-3 border-t border-[#eff1f8] pt-2.5">
@@ -377,5 +398,19 @@ export function StockDetailMain({
         </div>
       </div>
     </div>
+    {loginModalOpen && (
+      <LoginModal
+        onClose={() => setLoginModalOpen(false)}
+        onSignup={() => {
+          setLoginModalOpen(false);
+          navigate("/signup");
+        }}
+        onLoginSuccess={async () => {
+          await refreshAuth();
+          setLoginModalOpen(false);
+        }}
+      />
+    )}
+    </>
   );
 }

--- a/src/pages/Chart/components/StockInfoBar.tsx
+++ b/src/pages/Chart/components/StockInfoBar.tsx
@@ -1,12 +1,43 @@
-import { useState } from "react";
+import { useAuth } from "@/features/auth/context/AuthContext";
+import {
+  useAddInterestStockMutation,
+  useRemoveInterestStockMutation,
+} from "@/features/stock/hooks/useInterestStocks";
 import type { StockInfoBarProps } from "../types";
 import favoriteSrc from "@/assets/favorite.svg";
 import favoriteClickSrc from "@/assets/favorite_click.svg";
 
-export function StockInfoBar({ stock, onBack, onAddWatchlist }: StockInfoBarProps) {
+export function StockInfoBar({
+  stock,
+  stockId,
+  isInterested = false,
+  onBack,
+  onAddWatchlist,
+  onRequireLogin,
+}: StockInfoBarProps) {
   const changeColor = stock.positive ? "text-[#e03131]" : "text-[#1971c2]";
   const arrow = stock.positive ? "▲" : "▼";
-  const [isFavorite, setIsFavorite] = useState(false);
+  const { isLoggedIn } = useAuth();
+  const addMut = useAddInterestStockMutation();
+  const removeMut = useRemoveInterestStockMutation();
+  const pending = addMut.isPending || removeMut.isPending;
+
+  const handleFavoriteClick = () => {
+    if (!isLoggedIn) {
+      onRequireLogin?.();
+      return;
+    }
+    if (stockId == null || stockId <= 0) return;
+    if (isInterested) {
+      removeMut.mutate(stockId, {
+        onSuccess: () => onAddWatchlist?.(),
+      });
+    } else {
+      addMut.mutate(stockId, {
+        onSuccess: () => onAddWatchlist?.(),
+      });
+    }
+  };
 
   return (
     <div className="flex min-h-[44px] items-center gap-4 max-md:flex-wrap max-md:gap-x-3 max-md:gap-y-1.5">
@@ -57,21 +88,19 @@ export function StockInfoBar({ stock, onBack, onAddWatchlist }: StockInfoBarProp
 
       <button
         type="button"
-        onClick={() => {
-          setIsFavorite((prev) => !prev);
-          onAddWatchlist?.();
-        }}
-        className="ml-auto flex h-9 shrink-0 items-center justify-center gap-1 rounded-lg border border-[#e5e7eb] bg-white px-3 text-[13px] font-medium text-[#374151] transition-colors hover:bg-[#f9fafb] max-[860px]:w-9 max-[860px]:px-0 max-md:order-3"
+        onClick={handleFavoriteClick}
+        disabled={pending || (isLoggedIn && (stockId == null || stockId <= 0))}
+        className="ml-auto flex h-9 shrink-0 items-center justify-center gap-1 rounded-lg border border-[#e5e7eb] bg-white px-3 text-[13px] font-medium text-[#374151] transition-colors hover:bg-[#f9fafb] max-[860px]:w-9 max-[860px]:px-0 max-md:order-3 disabled:opacity-60"
       >
         <img
-          src={isFavorite ? favoriteClickSrc : favoriteSrc}
+          src={isInterested ? favoriteClickSrc : favoriteSrc}
           alt=""
           className="h-4.5 w-4.5 shrink-0"
           width={14}
           height={14}
           aria-hidden
         />
-        <span className="max-[860px]:hidden">관심종목 추가</span>
+        <span className="max-[860px]:hidden">{isInterested ? "관심종목 해제" : "관심종목 추가"}</span>
       </button>
     </div>
   );

--- a/src/pages/Chart/types/index.ts
+++ b/src/pages/Chart/types/index.ts
@@ -81,8 +81,14 @@ export interface OhlcSummaryBarProps {
 
 export interface StockInfoBarProps {
   stock: StockInfo;
+  /** 차트 종목 ID — 관심 추가/해제 API에 사용 */
+  stockId?: number | null;
+  /** 로그인 + 관심 목록 기준 표시 */
+  isInterested?: boolean;
   onBack?: () => void;
   onAddWatchlist?: () => void;
+  /** 비로그인 시 관심 버튼 클릭 */
+  onRequireLogin?: () => void;
 }
 
 export interface TickerBarProps {

--- a/src/pages/Home/components/HomeLayout.tsx
+++ b/src/pages/Home/components/HomeLayout.tsx
@@ -1,5 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useAuth } from '@/features/auth/context/AuthContext';
 import { fetchStockList } from '@/features/stock/api';
+import {
+  useAddInterestStockMutation,
+  useInterestStocksQuery,
+  useRemoveInterestStockMutation,
+} from '@/features/stock/hooks/useInterestStocks';
 import type { HomeStockItemDto, StockMarket, StockPeriod, StockSort } from '@/features/stock/types';
 import favoriteIco from '@/assets/favorite.svg';
 import favoriteClickIco from '@/assets/favorite_click.svg';
@@ -14,6 +20,8 @@ interface HomeLayoutProps {
   onChangeMarket: (market: StockMarket) => void;
   onChangeSort: (sort: StockSort) => void;
   onChangePeriod: (period: StockPeriod) => void;
+  /** 비로그인 시 홈에서 관심(별) 클릭 */
+  onRequireLoginForFavorite?: () => void;
 }
 
 interface HomeStockRow {
@@ -111,8 +119,17 @@ export default function HomeLayout({
   onChangeMarket,
   onChangeSort,
   onChangePeriod,
+  onRequireLoginForFavorite,
 }: HomeLayoutProps) {
   const navigate = useNavigate();
+  const { isLoggedIn } = useAuth();
+  const { data: interestItems = [] } = useInterestStocksQuery();
+  const interestIdSet = useMemo(
+    () => new Set(interestItems.map((i) => i.stockId)),
+    [interestItems]
+  );
+  const addInterestMut = useAddInterestStockMutation();
+  const removeInterestMut = useRemoveInterestStockMutation();
   const marketOptions: StockMarket[] = ['ALL', 'KOSPI', 'KOSDAQ'];
   const sortOptions: StockSort[] = ['TRADING_AMOUNT', 'TRADING_VOLUME', 'SURGE', 'DROP'];
   /** 리스트 등락률 기준 기간(스톡 프라이스 차트 기간과 다름) */
@@ -201,16 +218,27 @@ export default function HomeLayout({
     return () => observer.disconnect();
   }, [loadNextPage]);
 
-  const [favorites, setFavorites] = useState<Set<string>>(() => new Set());
-
-  const toggleFavorite = useCallback((ticker: string) => {
-    setFavorites(prev => {
-      const next = new Set(prev);
-      if (next.has(ticker)) next.delete(ticker);
-      else next.add(ticker);
-      return next;
-    });
-  }, []);
+  const toggleFavorite = useCallback(
+    (stockId: number, e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!isLoggedIn) {
+        onRequireLoginForFavorite?.();
+        return;
+      }
+      if (interestIdSet.has(stockId)) {
+        removeInterestMut.mutate(stockId);
+      } else {
+        addInterestMut.mutate(stockId);
+      }
+    },
+    [
+      isLoggedIn,
+      interestIdSet,
+      addInterestMut,
+      removeInterestMut,
+      onRequireLoginForFavorite,
+    ]
+  );
 
   return (
     <main className="flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden bg-[#f4f6fb]">
@@ -309,15 +337,13 @@ export default function HomeLayout({
                 >
                   <button
                     type="button"
-                    onClick={e => {
-                      e.stopPropagation();
-                      toggleFavorite(stock.ticker);
-                    }}
+                    onClick={e => toggleFavorite(stock.stockId, e)}
                     className="pl-1 translate-x-1 text-gray-300"
-                    aria-pressed={favorites.has(stock.ticker)}
+                    aria-pressed={interestIdSet.has(stock.stockId)}
+                    disabled={addInterestMut.isPending || removeInterestMut.isPending}
                   >
                     <img
-                      src={favorites.has(stock.ticker) ? favoriteClickIco : favoriteIco}
+                      src={interestIdSet.has(stock.stockId) ? favoriteClickIco : favoriteIco}
                       alt="관심 종목"
                       className="h-[18px] w-[18px]"
                     />
@@ -399,15 +425,13 @@ export default function HomeLayout({
                   <div className="flex min-w-0 items-center gap-2">
                     <button
                       type="button"
-                      onClick={e => {
-                        e.stopPropagation();
-                        toggleFavorite(stock.ticker);
-                      }}
+                      onClick={e => toggleFavorite(stock.stockId, e)}
                       className="shrink-0 -translate-x-0.8 text-gray-300"
-                      aria-pressed={favorites.has(stock.ticker)}
+                      aria-pressed={interestIdSet.has(stock.stockId)}
+                      disabled={addInterestMut.isPending || removeInterestMut.isPending}
                     >
                       <img
-                        src={favorites.has(stock.ticker) ? favoriteClickIco : favoriteIco}
+                        src={interestIdSet.has(stock.stockId) ? favoriteClickIco : favoriteIco}
                         alt="관심 종목"
                         className="h-[18px] w-[18px]"
                       />

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,4 +1,7 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router';
+import LoginModal from '@/features/auth/components/LoginModal';
+import { useAuth } from '@/features/auth/context/AuthContext';
 import type { StockMarket, StockPeriod, StockSort } from '@/features/stock/types';
 import HomeLayout from './components/HomeLayout';
 
@@ -7,18 +10,37 @@ const DEFAULT_SORT: StockSort = 'TRADING_AMOUNT';
 const DEFAULT_PERIOD: StockPeriod = '1D';
 
 export default function HomePage() {
+  const navigate = useNavigate();
+  const { refreshAuth } = useAuth();
+  const [loginOpen, setLoginOpen] = useState(false);
   const [market, setMarket] = useState<StockMarket>(DEFAULT_MARKET);
   const [sort, setSort] = useState<StockSort>(DEFAULT_SORT);
   const [period, setPeriod] = useState<StockPeriod>(DEFAULT_PERIOD);
 
   return (
-    <HomeLayout
-      market={market}
-      sort={sort}
-      period={period}
-      onChangeMarket={setMarket}
-      onChangeSort={setSort}
-      onChangePeriod={setPeriod}
-    />
+    <>
+      <HomeLayout
+        market={market}
+        sort={sort}
+        period={period}
+        onChangeMarket={setMarket}
+        onChangeSort={setSort}
+        onChangePeriod={setPeriod}
+        onRequireLoginForFavorite={() => setLoginOpen(true)}
+      />
+      {loginOpen && (
+        <LoginModal
+          onClose={() => setLoginOpen(false)}
+          onSignup={() => {
+            setLoginOpen(false);
+            navigate('/signup');
+          }}
+          onLoginSuccess={async () => {
+            await refreshAuth();
+            setLoginOpen(false);
+          }}
+        />
+      )}
+    </>
   );
 }

--- a/src/pages/InterestStock/components/InterestStockAside.tsx
+++ b/src/pages/InterestStock/components/InterestStockAside.tsx
@@ -24,72 +24,55 @@ import lockIco from '@/assets/lock.svg';
 import deleteIco from '@/assets/delete.svg';
 import dragHandleIco from '@/assets/button.svg';
 import { useAuth } from '@/features/auth/context/AuthContext';
+import type { InterestStockItemDto } from '@/features/stock/types';
+import {
+  useInterestStocksQuery,
+  useRemoveInterestStockMutation,
+} from '@/features/stock/hooks/useInterestStocks';
 import { useNavigate } from 'react-router';
 import { toChartStockDetail } from '@/shared/constants/routes';
 
 type WatchRow = {
+  stockId: number;
   name: string;
   code: string;
   market: string;
   initials: string;
   logoBg: string;
+  logoUrl?: string | null;
   price: string;
   changeLabel: string;
   up: boolean;
 };
 
-const INITIAL_WATCHLIST: WatchRow[] = [
-  {
-    name: '삼성전자',
-    code: '005930',
-    market: 'KOSPI',
-    initials: '삼',
-    logoBg: '#1428a0',
-    price: '184,000',
-    changeLabel: '▼ -2.08%',
-    up: false,
-  },
-  {
-    name: 'SK하이닉스',
-    code: '000660',
-    market: 'KOSPI',
-    initials: 'SK',
-    logoBg: '#EA1917',
-    price: '915,000',
-    changeLabel: '▲ +3.21%',
-    up: true,
-  },
-  {
-    name: 'LG에너지솔루션',
-    code: '373220',
-    market: 'KOSDAQ',
-    initials: 'LG',
-    logoBg: '#a50034',
-    price: '305,500',
-    changeLabel: '▲ +5.14%',
-    up: true,
-  },
-  {
-    name: 'NAVER',
-    code: '035420',
-    market: 'KOSPI',
-    initials: 'N',
-    logoBg: '#03c75a',
-    price: '198,500',
-    changeLabel: '▲ +1.85%',
-    up: true,
-  },
-  {
-    name: '알테오젠',
-    code: '196170',
-    market: 'KOSDAQ',
-    initials: '알',
-    logoBg: '#059669',
-    price: '361,000',
-    changeLabel: '▼ -3.08%',
-    up: false,
-  },
-];
+function logoSeedColor(seed: string) {
+  const palette = ['#002C5F', '#1428a0', '#EA1917', '#a50034', '#03c75a', '#059669'];
+  const hash = seed.split('').reduce((acc, ch) => acc + ch.charCodeAt(0), 0);
+  return palette[hash % palette.length];
+}
+
+function interestToWatchRow(item: InterestStockItemDto): WatchRow {
+  const up = item.changeDirection === 'UP';
+  const rate = item.changeRate ?? 0;
+  const changeLabel =
+    rate > 0
+      ? `▲ +${rate.toFixed(2)}%`
+      : rate < 0
+        ? `▼ ${rate.toFixed(2)}%`
+        : '0.00%';
+  return {
+    stockId: item.stockId,
+    name: item.name,
+    code: item.ticker,
+    market: item.market,
+    initials: item.name.trim().slice(0, 1),
+    logoBg: logoSeedColor(item.ticker),
+    logoUrl: item.logoUrl ?? null,
+    price: `${Number(item.currentPrice).toLocaleString('ko-KR')}원`,
+    changeLabel,
+    up,
+  };
+}
 
 function getWatchLogoText(row: WatchRow) {
   if (row.name === 'SK하이닉스') return 'SK';
@@ -100,12 +83,20 @@ function getWatchLogoText(row: WatchRow) {
 function WatchIdentityBlock({ row, showMarket = true }: { row: WatchRow; showMarket?: boolean }) {
   return (
     <div className="flex min-w-0 flex-1 items-center gap-2.5">
-      <div
-        className="flex h-[28px] w-[28px] shrink-0 items-center justify-center rounded-[7px] text-[9px] font-black leading-[13.5px] text-white max-md:-translate-y-[0.8px]"
-        style={{ backgroundColor: row.logoBg }}
-      >
-        <span className="max-md:translate-y-[1px]">{getWatchLogoText(row)}</span>
-      </div>
+      {row.logoUrl ? (
+        <img
+          src={row.logoUrl}
+          alt=""
+          className="h-[28px] w-[28px] shrink-0 rounded-[7px] object-cover max-md:-translate-y-[0.8px]"
+        />
+      ) : (
+        <div
+          className="flex h-[28px] w-[28px] shrink-0 items-center justify-center rounded-[7px] text-[9px] font-black leading-[13.5px] text-white max-md:-translate-y-[0.8px]"
+          style={{ backgroundColor: row.logoBg }}
+        >
+          <span className="max-md:translate-y-[1px]">{getWatchLogoText(row)}</span>
+        </div>
+      )}
       <div className="min-w-0 overflow-hidden">
         <div className="text-[12.5px] font-bold leading-[18.75px] text-[#111827]">{row.name}</div>
         <div className="font-mono text-[10px] leading-[15px] text-[#9ca3af]">
@@ -121,10 +112,10 @@ function SortableEditRow({
   onRemove,
 }: {
   row: WatchRow;
-  onRemove: (code: string) => void;
+  onRemove: (stockId: number) => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: row.code,
+    id: row.stockId,
   });
 
   const style = {
@@ -151,7 +142,7 @@ function SortableEditRow({
           aria-label={`${row.name} 관심종목에서 제거`}
           onClick={(e) => {
             e.stopPropagation();
-            onRemove(row.code);
+            onRemove(row.stockId);
           }}
           onPointerDown={(e) => e.stopPropagation()}
         >
@@ -196,9 +187,19 @@ function EditRowOverlay({ row }: { row: WatchRow }) {
 export default function InterestStockAside() {
   const navigate = useNavigate();
   const { isLoggedIn } = useAuth();
+  const { data: interestData, isLoading, isError } = useInterestStocksQuery();
+  const removeMut = useRemoveInterestStockMutation();
+
   const [editMode, setEditMode] = useState(false);
-  const [items, setItems] = useState<WatchRow[]>(() => [...INITIAL_WATCHLIST]);
-  const [activeId, setActiveId] = useState<string | null>(null);
+  const [orderOverride, setOrderOverride] = useState<WatchRow[] | null>(null);
+  const [activeId, setActiveId] = useState<number | null>(null);
+
+  const baseRows = useMemo(
+    () => (interestData ?? []).map(interestToWatchRow),
+    [interestData]
+  );
+
+  const items = orderOverride ?? baseRows;
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -206,32 +207,43 @@ export default function InterestStockAside() {
     }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
-    }),
+    })
   );
 
-  const sortableIds = useMemo(() => items.map((r) => r.code), [items]);
+  const sortableIds = useMemo(() => items.map((r) => r.stockId), [items]);
 
   useEffect(() => {
     if (!isLoggedIn) setEditMode(false);
   }, [isLoggedIn]);
 
-  const removeItem = useCallback((code: string) => {
-    setItems((prev) => prev.filter((row) => row.code !== code));
-  }, []);
+  useEffect(() => {
+    setOrderOverride(null);
+  }, [interestData]);
+
+  const removeItem = useCallback(
+    (stockId: number) => {
+      removeMut.mutate(stockId);
+      setOrderOverride((prev) =>
+        prev ? prev.filter((r) => r.stockId !== stockId) : null
+      );
+    },
+    [removeMut]
+  );
 
   const handleDragStart = (event: DragStartEvent) => {
-    setActiveId(String(event.active.id));
+    setActiveId(Number(event.active.id));
   };
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
     setActiveId(null);
     if (!over || active.id === over.id) return;
-    setItems((prev) => {
-      const oldIndex = prev.findIndex((i) => i.code === active.id);
-      const newIndex = prev.findIndex((i) => i.code === over.id);
+    setOrderOverride((prev) => {
+      const list = prev ?? baseRows;
+      const oldIndex = list.findIndex((i) => i.stockId === active.id);
+      const newIndex = list.findIndex((i) => i.stockId === over.id);
       if (oldIndex < 0 || newIndex < 0) return prev;
-      return arrayMove(prev, oldIndex, newIndex);
+      return arrayMove(list, oldIndex, newIndex);
     });
   };
 
@@ -239,7 +251,7 @@ export default function InterestStockAside() {
     setActiveId(null);
   };
 
-  const activeRow = activeId ? items.find((r) => r.code === activeId) : null;
+  const activeRow = activeId != null ? items.find((r) => r.stockId === activeId) : null;
 
   return (
     <aside className="flex h-full w-full flex-col overflow-hidden bg-white">
@@ -269,7 +281,20 @@ export default function InterestStockAside() {
 
       {isLoggedIn ? (
         <div className="scrollbar-subtle flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden">
-          {editMode ? (
+          {isLoading && (
+            <div className="px-4 py-8 text-center text-sm text-[#9ca3af]">불러오는 중…</div>
+          )}
+          {isError && !isLoading && (
+            <div className="px-4 py-8 text-center text-sm text-red-500">
+              관심 종목을 불러오지 못했습니다.
+            </div>
+          )}
+          {!isLoading && !isError && items.length === 0 && (
+            <div className="px-4 py-8 text-center text-sm text-[#9ca3af]">
+              등록된 관심 종목이 없습니다.
+            </div>
+          )}
+          {!isLoading && !isError && items.length > 0 && editMode && (
             <DndContext
               sensors={sensors}
               collisionDetection={closestCorners}
@@ -279,31 +304,33 @@ export default function InterestStockAside() {
             >
               <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
                 {items.map((row) => (
-                  <SortableEditRow key={row.code} row={row} onRemove={removeItem} />
+                  <SortableEditRow key={row.stockId} row={row} onRemove={removeItem} />
                 ))}
               </SortableContext>
               <DragOverlay adjustScale={false} dropAnimation={null} className="pointer-events-none">
                 {activeRow ? <EditRowOverlay row={activeRow} /> : null}
               </DragOverlay>
             </DndContext>
-          ) : (
+          )}
+          {!isLoading && !isError && items.length > 0 && !editMode &&
             items.map((row) => {
               const priceColor = row.up ? 'text-red-600' : 'text-blue-700';
               return (
                 <div
-                  key={row.code}
+                  key={row.stockId}
                   onClick={() => navigate(toChartStockDetail(row.code))}
                   className="box-border grid h-[58px] w-full shrink-0 grid-cols-[minmax(0,1fr)_74px] items-center overflow-hidden border-0 border-b border-[#e5e7eb] bg-white px-4 text-left transition-colors hover:bg-[#f4f5f7]"
                 >
                   <WatchIdentityBlock row={row} showMarket={false} />
-                  <div className={`ml-auto w-[74px] text-right text-[11.5px] font-semibold leading-[17px] tabular-nums ${priceColor}`}>
+                  <div
+                    className={`ml-auto w-[74px] text-right text-[11.5px] font-semibold leading-[17px] tabular-nums ${priceColor}`}
+                  >
                     <div>{row.price}</div>
                     <div>{row.changeLabel}</div>
                   </div>
                 </div>
               );
-            })
-          )}
+            })}
         </div>
       ) : (
         <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center">

--- a/src/pages/widgets/SearchDropdown/SearchDropdown.tsx
+++ b/src/pages/widgets/SearchDropdown/SearchDropdown.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import searchSrc from "@/assets/search.svg";
 import type { StockSearchItemDto } from "@/features/stock/types";
 import { logoColor, logoInitial } from "./searchShared";
@@ -7,6 +8,13 @@ import { useStockSearchPanel } from "./useStockSearchPanel";
 export default function SearchDropdown() {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [panelLayout, setPanelLayout] = useState<{
+    top: number;
+    left: number;
+    width: number;
+  } | null>(null);
+
   const {
     query,
     setQuery,
@@ -23,12 +31,36 @@ export default function SearchDropdown() {
     onAfterPick: () => setOpen(false),
   });
 
+  useLayoutEffect(() => {
+    if (!open) {
+      setPanelLayout(null);
+      return;
+    }
+    const update = () => {
+      const el = wrapRef.current;
+      if (!el) return;
+      const r = el.getBoundingClientRect();
+      setPanelLayout({
+        top: r.bottom + 8,
+        left: r.left + r.width / 2,
+        width: Math.min(620, window.innerWidth - 48),
+      });
+    };
+    update();
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    return () => {
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+    };
+  }, [open]);
+
   useEffect(() => {
     if (!open) return;
     const onDown = (e: MouseEvent) => {
-      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
+      const t = e.target as Node;
+      if (wrapRef.current?.contains(t) || panelRef.current?.contains(t)) return;
+      setOpen(false);
     };
     document.addEventListener("mousedown", onDown);
     return () => document.removeEventListener("mousedown", onDown);
@@ -98,99 +130,121 @@ export default function SearchDropdown() {
     );
   };
 
-  return (
-    <div
-      ref={wrapRef}
-      className="relative mx-6 flex min-w-0 max-w-[514px] flex-1"
-    >
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="flex h-8 w-full cursor-pointer items-center justify-center gap-2 rounded-lg border border-[rgba(2,32,71,0.05)] bg-[#f0f4f9] px-4"
-        aria-expanded={open}
-        aria-haspopup="dialog"
+  const searchPanel =
+    open && panelLayout ? (
+      <div
+        ref={panelRef}
+        className="search-dropdown search-dropdown--portal"
+        role="dialog"
+        aria-label="검색"
+        style={{
+          top: panelLayout.top,
+          left: panelLayout.left,
+          width: panelLayout.width,
+          transform: "translateX(-50%)",
+        }}
       >
-        <img src={searchSrc} alt="" className="h-3.5 w-3.5 shrink-0" width={14} height={14} />
-        <span className="min-w-0 truncate font-sans text-[13.1px] font-medium leading-[20.3px] tracking-normal text-[#6b7684]">
-          검색어를 입력해주세요
-        </span>
-      </button>
-
-      {open && (
-        <div className="search-dropdown" role="dialog" aria-label="검색">
-          <div className="border-b border-[#f3f4f6] px-3 pb-2 pt-2.5">
-            <div className="flex items-center gap-2 rounded-lg border border-[#e5e7eb] bg-[#f9fafb] px-3 py-1.5">
-              <img src={searchSrc} alt="" className="h-3.5 w-3.5 shrink-0 opacity-60" width={14} height={14} />
-              <input
-                ref={inputRef}
-                type="search"
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                placeholder="종목명 또는 종목코드"
-                className="min-w-0 flex-1 border-0 bg-transparent font-sans text-[13px] text-[#111827] outline-none placeholder:text-[#9ca3af]"
-                autoComplete="off"
-                spellCheck={false}
-              />
-            </div>
+        <div className="border-b border-[#f3f4f6] px-3 pb-2 pt-2.5">
+          <div className="flex items-center gap-2 rounded-lg border border-[rgba(2,32,71,0.05)] bg-[#f0f4f9] px-3 py-1.5">
+            <img src={searchSrc} alt="" className="h-3.5 w-3.5 shrink-0 opacity-60" width={14} height={14} />
+            <input
+              ref={inputRef}
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="종목명 또는 종목코드"
+              className="min-w-0 flex-1 border-0 bg-transparent font-sans text-[13px] text-[#111827] outline-none placeholder:text-[#9ca3af]"
+              autoComplete="off"
+              spellCheck={false}
+            />
           </div>
-
-          {showResults ? (
-            <div className="max-h-[min(60vh,420px)] overflow-y-auto pb-1">
-              <div className="px-4 pb-1 pt-2 font-sans text-xs font-bold text-[#374151]">
-                검색 결과
-                {results != null && (
-                  <span className="ml-1 font-normal text-[#9ca3af]">
-                    {loading ? "" : `· ${results.length}건`}
-                  </span>
-                )}
-              </div>
-              {loading && (
-                <div className="px-4 py-6 text-center font-sans text-sm text-[#9ca3af]">
-                  검색 중…
-                </div>
-              )}
-              {!loading && error && (
-                <div className="px-4 py-4 text-center font-sans text-sm text-red-500">{error}</div>
-              )}
-              {!loading && !error && results && results.length === 0 && (
-                <div className="px-4 py-6 text-center font-sans text-sm text-[#9ca3af]">
-                  검색 결과가 없습니다.
-                </div>
-              )}
-              {!loading && !error && results && results.map((item) => renderResultRow(item))}
-            </div>
-          ) : (
-            <div className="search-recent-noto border-b border-[#f3f4f6] px-4 pb-3 pt-2">
-              <div className="mb-2.5 text-xs font-bold text-[#374151]">최근 검색</div>
-              {recent.length === 0 ? (
-                <p className="text-xs text-[#9ca3af]">최근 검색 내역이 없습니다.</p>
-              ) : (
-                <div className="flex flex-wrap gap-1.5">
-                  {recent.map((row) => (
-                    <div key={row.ticker} className="search-tag">
-                      <button
-                        type="button"
-                        className="border-0 bg-transparent p-0 text-[12px] font-medium leading-none text-[#374151]"
-                        onClick={() => goToStock(row.ticker, row.name)}
-                      >
-                        {row.name}
-                      </button>
-                      <button
-                        type="button"
-                        className="ml-0.5 border-0 bg-transparent p-0 text-[11px] leading-none text-[#9ca3af] hover:text-[#374151]"
-                        aria-label={`${row.name} 최근 검색에서 제거`}
-                        onClick={() => removeRecent(row.ticker)}
-                      >
-                        ×
-                      </button>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
         </div>
-      )}
-    </div>
+
+        {showResults ? (
+          <div className="max-h-[min(60vh,420px)] overflow-y-auto pb-1">
+            <div className="px-4 pb-1 pt-2 font-sans text-xs font-bold text-[#374151]">
+              검색 결과
+              {results != null && (
+                <span className="ml-1 font-normal text-[#9ca3af]">
+                  {loading ? "" : `· ${results.length}건`}
+                </span>
+              )}
+            </div>
+            {loading && (
+              <div className="px-4 py-6 text-center font-sans text-sm text-[#9ca3af]">
+                검색 중…
+              </div>
+            )}
+            {!loading && error && (
+              <div className="px-4 py-4 text-center font-sans text-sm text-red-500">{error}</div>
+            )}
+            {!loading && !error && results && results.length === 0 && (
+              <div className="px-4 py-6 text-center font-sans text-sm text-[#9ca3af]">
+                검색 결과가 없습니다.
+              </div>
+            )}
+            {!loading && !error && results && results.map((item) => renderResultRow(item))}
+          </div>
+        ) : (
+          <div className="search-recent-noto border-b border-[#f3f4f6] px-4 pb-3 pt-2">
+            <div className="mb-2.5 text-xs font-bold text-[#374151]">최근 검색</div>
+            {recent.length === 0 ? (
+              <p className="text-xs text-[#9ca3af]">최근 검색 내역이 없습니다.</p>
+            ) : (
+              <div className="flex flex-wrap gap-1.5">
+                {recent.map((row) => (
+                  <div key={row.ticker} className="search-tag">
+                    <button
+                      type="button"
+                      className="border-0 bg-transparent p-0 text-[12px] font-medium leading-none text-[#374151]"
+                      onClick={() => goToStock(row.ticker, row.name)}
+                    >
+                      {row.name}
+                    </button>
+                    <button
+                      type="button"
+                      className="ml-0.5 border-0 bg-transparent p-0 text-[11px] leading-none text-[#9ca3af] hover:text-[#374151]"
+                      aria-label={`${row.name} 최근 검색에서 제거`}
+                      onClick={() => removeRecent(row.ticker)}
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    ) : null;
+
+  return (
+    <>
+      {open &&
+        createPortal(
+          <button
+            type="button"
+            className="fixed inset-0 z-[200] hidden cursor-default bg-black/15 md:block"
+            aria-label="검색 닫기"
+            onClick={() => setOpen(false)}
+          />,
+          document.body
+        )}
+      {open && searchPanel && createPortal(searchPanel, document.body)}
+      <div ref={wrapRef} className="relative mx-6 flex min-w-0 max-w-[514px] flex-1">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="flex h-8 w-full cursor-pointer items-center justify-center gap-2 rounded-lg border border-[rgba(2,32,71,0.05)] bg-[#f0f4f9] px-4"
+          aria-expanded={open}
+          aria-haspopup="dialog"
+        >
+          <img src={searchSrc} alt="" className="h-3.5 w-3.5 shrink-0" width={14} height={14} />
+          <span className="min-w-0 truncate font-sans text-[13.1px] font-medium leading-[20.3px] tracking-normal text-[#6b7684]">
+            검색어를 입력해주세요
+          </span>
+        </button>
+      </div>
+    </>
   );
 }

--- a/src/pages/widgets/SearchDropdown/StockSearchPanelBody.tsx
+++ b/src/pages/widgets/SearchDropdown/StockSearchPanelBody.tsx
@@ -94,7 +94,7 @@ export function StockSearchPanelBody({
   return (
     <div className={variant === "sheet" ? "flex min-h-0 flex-1 flex-col" : ""}>
       <div className={`border-b border-gray-200 ${pad}`}>
-        <div className="flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2">
+        <div className="flex items-center gap-2 rounded-lg border border-[rgba(2,32,71,0.05)] bg-[#f0f4f9] px-3 py-2">
           <img src={searchIcon} alt="" className="h-4 w-4 opacity-60" />
           <input
             ref={inputRef}


### PR DESCRIPTION
## #️⃣ Issue Number
<!--- ex) #이슈번호, #이슈번호 -->
- Closes #63

## 📝 변경사항
관심 종목 백엔드 API(GET/POST/DELETE /api/me/interest-stocks)를 프론트에 연동했습니다. 홈·차트·우측 관심 패널에서 동일한 목록·추가·삭제가 동작하도록 했고, 종목 이동·차트 조회는 비로그인 유지, 관심 추가/해제·목록 조회만 로그인 필요하도록 맞췄습니다.

### 🎯 핵심 변경 사항 (Key Changes)

- [x] interestStockApi + InterestStockItemDto 타입, React Query 훅(useInterestStocksQuery, add/remove mutation)으로 관심 종목 조회·추가·삭제
- [x] InterestStockAside: 목업 제거, 로그인 시 API 목록 표시, 편집 모드 삭제 시 DELETE 연동(드래그 순서는 서버 미연동·로컬만)
- [x] HomeLayout: 홈 리스트 별(관심) 아이콘을 API와 동기화, 비로그인 시 별 클릭 → 로그인 모달(HomePage)
- [x] StockInfoBar / StockDetailMain: stockId·isInterested로 관심 버튼 연동, 비로그인 시 관심 클릭 → 로그인 모달

### 🔍 주안점 & 리뷰 포인트
- axios apiClient는 withCredentials: true이므로 세션 쿠키 기준 동작이 백엔드 CORS·쿠키 설정과 맞는지 확인 부탁드립니다.
- 관심 패널에서 드래그 순서는 서버에 저장되지 않습니다(목록 순서 API가 없으면 새로고침 시 GET 순서로 복귀).
- DELETE는 REST 관례로 구현했습니다. 백엔드 스펙이 다르면 interestStockApi.ts만 조정하면 됩니다.

### 🖼️ 스크린샷 / 테스트 결과 (선택 사항)
(로그인 전/후 홈 별 아이콘, 관심 패널 목록, 차트 관심 버튼 캡처 첨부 권장)

---

## 🛠️ PR 유형
- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## 🧪 영향 범위 및 테스트 (Impact & Tests)

### **영향을 받는 모듈/컴포넌트:**
- src/features/stock/api/interestStockApi.ts, src/features/stock/hooks/useInterestStocks.ts, src/features/stock/types/*
- src/pages/InterestStock/components/InterestStockAside.tsx
- src/pages/Home/components/HomeLayout.tsx, src/pages/Home/index.tsx
- src/pages/Chart/components/StockInfoBar.tsx, StockDetailMain.tsx, src/pages/Chart/types/*

### **테스트 방법:**
- [ ] 단위 테스트 (JUnit/Jest)
- [ ] 통합 테스트
- [x] 수동 API 테스트 (Postman/Swagger) — 로그인 후 쿠키로 GET/POST/DELETE 확인
- [x] 수동 UI — 비로그인: 별/관심 버튼 → 로그인 모달, 로그인: 목록·추가·삭제·우측 패널 일치 여부

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 불필요한 로그나 주석을 제거했습니다.
- [ ] 관련 이슈를 연결했습니다.