### PR TITLE
feat(stocks): 하단 종목 정보 바 API 연동

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,14 @@
 VITE_API_BASE_URL=http://localhost:8080
 
+# LS Open API OAuth (선택 — 하단 시세·REST 연동 시)
+# https://openapi.ls-sec.co.kr — 시크릿은 절대 Git에 커밋하지 말고 .env.local 사용
+# VITE_LS_APP_KEY=
+# VITE_LS_APP_SECRET=
+# 직접 LS 도메인 호출 시(CORS 허용되는 경우만). 미설정 시 dev는 Vite 프록시 /ls-oauth/oauth2/token 사용
+# VITE_LS_OAUTH_URL=
+# 시세 REST(POST stock/market-data). 미설정 시 dev는 /ls-api/stock/market-data 프록시
+# VITE_LS_MARKET_DATA_URL=
+
 # Firebase FCM
 VITE_FIREBASE_API_KEY=
 VITE_FIREBASE_AUTH_DOMAIN=
@@ -8,3 +17,5 @@ VITE_FIREBASE_STORAGE_BUCKET=
 VITE_FIREBASE_MESSAGING_SENDER_ID=
 VITE_FIREBASE_APP_ID=
 VITE_FIREBASE_VAPID_KEY=
+VITE_LS_APP_KEY=
+VITE_LS_APP_SECRET=

--- a/src/features/ls/fetchT1101Quote.ts
+++ b/src/features/ls/fetchT1101Quote.ts
@@ -25,6 +25,33 @@ function normalizeShcode(shcode: string): string {
   return shcode.trim().toUpperCase();
 }
 
+/** 0092B0, 0167A0, 0105E0 등 — t1101보다 t1901(ETF)이 먼저 맞는 경우 */
+function isEtfStyleShcode(shcode: string): boolean {
+  return /[A-Z]/.test(normalizeShcode(shcode));
+}
+
+function isEmptyQuote(q: T1101Quote): boolean {
+  return !String(q.hname).trim() && q.price === 0 && q.change === 0;
+}
+
+export type TrPair = {
+  tr_cd: 't1101' | 't1901';
+  inKey: 't1101InBlock' | 't1901InBlock';
+  outKey: 't1101OutBlock' | 't1901OutBlock';
+};
+
+const TR_T1101: TrPair = {
+  tr_cd: 't1101',
+  inKey: 't1101InBlock',
+  outKey: 't1101OutBlock',
+};
+
+const TR_T1901: TrPair = {
+  tr_cd: 't1901',
+  inKey: 't1901InBlock',
+  outKey: 't1901OutBlock',
+};
+
 function blockToQuote(blk: Record<string, unknown>): T1101Quote {
   return {
     hname: String(blk.hname ?? ''),
@@ -34,12 +61,6 @@ function blockToQuote(blk: Record<string, unknown>): T1101Quote {
     sign: String(blk.sign ?? ''),
   };
 }
-
-type TrPair = {
-  tr_cd: 't1101' | 't1901';
-  inKey: 't1101InBlock' | 't1901InBlock';
-  outKey: 't1101OutBlock' | 't1901OutBlock';
-};
 
 async function fetchQuoteWithTr(
   shcode: string,
@@ -94,8 +115,9 @@ async function fetchQuoteWithTr(
 }
 
 /**
- * 현재가 조회: t1101(주식) 우선 → 실패 시 t1901(ETF 현재가) 폴백.
- * 영문 혼합 종목코드(0092B0, 0167A0 등)는 t1101에서 안 나오는 경우가 있어 ETF TR로 재요청.
+ * 현재가 조회.
+ * - 숫자-only 종목: t1101 → 실패·빈값 시 t1901
+ * - 영문 포함(0092B0 등): t1901 먼저(지연 없음) → 필요 시 t1101
  */
 export async function fetchT1101Quote(shcode: string): Promise<T1101Quote | null> {
   let token = getLsAccessToken();
@@ -104,32 +126,32 @@ export async function fetchT1101Quote(shcode: string): Promise<T1101Quote | null
   }
   if (!token) return null;
 
-  const t1101 = await fetchQuoteWithTr(shcode, {
-    tr_cd: 't1101',
-    inKey: 't1101InBlock',
-    outKey: 't1101OutBlock',
-  }, token);
-
-  if (t1101 != null) {
-    const empty =
-      !String(t1101.hname).trim() && t1101.price === 0 && t1101.change === 0;
-    if (!empty) {
+  if (isEtfStyleShcode(shcode)) {
+    const t1901 = await fetchQuoteWithTr(shcode, TR_T1901, token);
+    if (t1901 != null && !isEmptyQuote(t1901)) {
+      return t1901;
+    }
+    if (import.meta.env.DEV && t1901 != null) {
+      console.info('[LS] t1901 빈값 → t1101 시도', normalizeShcode(shcode));
+    }
+    const t1101 = await fetchQuoteWithTr(shcode, TR_T1101, token);
+    if (t1101 != null && !isEmptyQuote(t1101)) {
       return t1101;
     }
-    if (import.meta.env.DEV) {
-      console.info('[LS] t1101 데이터 없음 → t1901 시도', normalizeShcode(shcode));
-    }
+    return t1901 ?? t1101;
   }
 
-  const t1901 = await fetchQuoteWithTr(shcode, {
-    tr_cd: 't1901',
-    inKey: 't1901InBlock',
-    outKey: 't1901OutBlock',
-  }, token);
+  const t1101 = await fetchQuoteWithTr(shcode, TR_T1101, token);
+  if (t1101 != null && !isEmptyQuote(t1101)) {
+    return t1101;
+  }
+  if (import.meta.env.DEV && t1101 != null) {
+    console.info('[LS] t1101 데이터 없음 → t1901 시도', normalizeShcode(shcode));
+  }
 
+  const t1901 = await fetchQuoteWithTr(shcode, TR_T1901, token);
   if (t1901 != null && import.meta.env.DEV) {
     console.info('[LS] t1901 폴백 성공', normalizeShcode(shcode));
   }
-
   return t1901;
 }

--- a/src/features/ls/fetchT1101Quote.ts
+++ b/src/features/ls/fetchT1101Quote.ts
@@ -1,0 +1,135 @@
+import { getLsAccessToken, fetchLsAccessToken } from './lsTokenScheduler';
+import { getLsMarketDataPostUrl } from './lsMarketDataUrl';
+
+export type T1101Quote = {
+  hname: string;
+  price: number;
+  /** 전일대비 절대값 */
+  change: number;
+  /** 등락률 % */
+  diffPct: number;
+  sign: string;
+};
+
+function parseNum(v: unknown): number {
+  if (typeof v === 'number' && !Number.isNaN(v)) return v;
+  if (typeof v === 'string') {
+    const n = parseFloat(v.trim());
+    return Number.isNaN(n) ? 0 : n;
+  }
+  return 0;
+}
+
+/** KRX 종목코드(숫자·영문 혼합) — LS는 대문자 6자 기대인 경우가 많음 */
+function normalizeShcode(shcode: string): string {
+  return shcode.trim().toUpperCase();
+}
+
+function blockToQuote(blk: Record<string, unknown>): T1101Quote {
+  return {
+    hname: String(blk.hname ?? ''),
+    price: parseNum(blk.price),
+    change: parseNum(blk.change),
+    diffPct: parseNum(blk.diff),
+    sign: String(blk.sign ?? ''),
+  };
+}
+
+type TrPair = {
+  tr_cd: 't1101' | 't1901';
+  inKey: 't1101InBlock' | 't1901InBlock';
+  outKey: 't1101OutBlock' | 't1901OutBlock';
+};
+
+async function fetchQuoteWithTr(
+  shcode: string,
+  pair: TrPair,
+  token: string
+): Promise<T1101Quote | null> {
+  const body = {
+    [pair.inKey]: {
+      shcode: normalizeShcode(shcode),
+    },
+  } as Record<string, { shcode: string }>;
+
+  const res = await fetch(getLsMarketDataPostUrl(), {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      authorization: `Bearer ${token}`,
+      tr_cd: pair.tr_cd,
+      tr_cont: 'N',
+      tr_cont_key: '',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    if (import.meta.env.DEV) {
+      console.warn(`[LS ${pair.tr_cd}] HTTP`, shcode, res.status, text);
+    }
+    return null;
+  }
+
+  const json = (await res.json()) as {
+    rsp_cd?: string;
+    rsp_msg?: string;
+    t1101OutBlock?: Record<string, unknown>;
+    t1901OutBlock?: Record<string, unknown>;
+  };
+
+  if (json.rsp_cd && json.rsp_cd !== '00000') {
+    if (import.meta.env.DEV) {
+      console.warn(`[LS ${pair.tr_cd}] rsp_cd`, json.rsp_cd, json.rsp_msg ?? '', 'shcode=', shcode);
+    }
+    return null;
+  }
+
+  const blk =
+    pair.outKey === 't1101OutBlock' ? json.t1101OutBlock : json.t1901OutBlock;
+  if (!blk || typeof blk !== 'object') return null;
+
+  return blockToQuote(blk);
+}
+
+/**
+ * 현재가 조회: t1101(주식) 우선 → 실패 시 t1901(ETF 현재가) 폴백.
+ * 영문 혼합 종목코드(0092B0, 0167A0 등)는 t1101에서 안 나오는 경우가 있어 ETF TR로 재요청.
+ */
+export async function fetchT1101Quote(shcode: string): Promise<T1101Quote | null> {
+  let token = getLsAccessToken();
+  if (!token) {
+    token = await fetchLsAccessToken();
+  }
+  if (!token) return null;
+
+  const t1101 = await fetchQuoteWithTr(shcode, {
+    tr_cd: 't1101',
+    inKey: 't1101InBlock',
+    outKey: 't1101OutBlock',
+  }, token);
+
+  if (t1101 != null) {
+    const empty =
+      !String(t1101.hname).trim() && t1101.price === 0 && t1101.change === 0;
+    if (!empty) {
+      return t1101;
+    }
+    if (import.meta.env.DEV) {
+      console.info('[LS] t1101 데이터 없음 → t1901 시도', normalizeShcode(shcode));
+    }
+  }
+
+  const t1901 = await fetchQuoteWithTr(shcode, {
+    tr_cd: 't1901',
+    inKey: 't1901InBlock',
+    outKey: 't1901OutBlock',
+  }, token);
+
+  if (t1901 != null && import.meta.env.DEV) {
+    console.info('[LS] t1901 폴백 성공', normalizeShcode(shcode));
+  }
+
+  return t1901;
+}

--- a/src/features/ls/lsMarketDataUrl.ts
+++ b/src/features/ls/lsMarketDataUrl.ts
@@ -1,0 +1,9 @@
+export function getLsMarketDataPostUrl(): string {
+  if (import.meta.env.VITE_LS_MARKET_DATA_URL) {
+    return import.meta.env.VITE_LS_MARKET_DATA_URL;
+  }
+  if (import.meta.env.DEV) {
+    return '/ls-api/stock/market-data';
+  }
+  return 'https://openapi.ls-sec.co.kr:8080/stock/market-data';
+}

--- a/src/features/ls/lsTokenScheduler.ts
+++ b/src/features/ls/lsTokenScheduler.ts
@@ -1,0 +1,147 @@
+/**
+ * LS Open API OAuth2 access_token — 하루 1회 오전 6시 갱신 + 최초 부트스트랩.
+ *
+ * 공식 가이드: POST `oauth2/token`, param은 grant_type, appkey, appsecretkey, scope=oob
+ * (Python `requests.post(..., params=param)` = URL 쿼리로 전달)
+ *
+ * 환경: `VITE_LS_APP_KEY`, `VITE_LS_APP_SECRET` (`.env.local`, 커밋 금지)
+ */
+
+const STORAGE_KEY = 'ls_oauth_access_token';
+const SIX_AM_HOUR = 6;
+
+let accessToken: string | null =
+  typeof sessionStorage !== 'undefined' ? sessionStorage.getItem(STORAGE_KEY) : null;
+
+let dailySixAmTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+function getOAuthUrl(): string {
+  if (import.meta.env.VITE_LS_OAUTH_URL) {
+    return import.meta.env.VITE_LS_OAUTH_URL;
+  }
+  if (import.meta.env.DEV) {
+    return '/ls-oauth/oauth2/token';
+  }
+  return 'https://openapi.ls-sec.co.kr:8080/oauth2/token';
+}
+
+/** 공식 샘플과 동일: 쿼리스트링 + POST (본문 비움). 실패 시 x-www-form-urlencoded 본문으로 1회 재시도. */
+function resolveOAuthFetchUrl(): string {
+  const base = getOAuthUrl();
+  if (base.startsWith('http://') || base.startsWith('https://')) {
+    return base;
+  }
+  return new URL(base, typeof window !== 'undefined' ? window.location.origin : 'http://localhost').toString();
+}
+
+function msUntilNextSixAM(): number {
+  const now = new Date();
+  const next = new Date(now);
+  next.setHours(SIX_AM_HOUR, 0, 0, 0);
+  if (now >= next) {
+    next.setDate(next.getDate() + 1);
+  }
+  return next.getTime() - now.getTime();
+}
+
+function logDevTokenOk(prefix: string): void {
+  if (import.meta.env.DEV) {
+    console.info('[LS OAuth] 발급 성공 · 토큰 앞 12자:', `${prefix.slice(0, 12)}…`);
+  }
+}
+
+function logDevTokenFail(status: number, detail: string): void {
+  if (import.meta.env.DEV) {
+    console.warn('[LS OAuth] 발급 실패', status, detail);
+  }
+}
+
+export async function fetchLsAccessToken(): Promise<string | null> {
+  const appkey = import.meta.env.VITE_LS_APP_KEY?.trim();
+  const appsecretkey = import.meta.env.VITE_LS_APP_SECRET?.trim();
+  if (!appkey || !appsecretkey) {
+    if (import.meta.env.DEV) {
+      console.warn('[LS OAuth] VITE_LS_APP_KEY / VITE_LS_APP_SECRET 미설정(.env.local 확인)');
+    }
+    return accessToken;
+  }
+
+  const target = resolveOAuthFetchUrl();
+  const u = new URL(target);
+  u.searchParams.set('grant_type', 'client_credentials');
+  u.searchParams.set('appkey', appkey);
+  u.searchParams.set('appsecretkey', appsecretkey);
+  u.searchParams.set('scope', 'oob');
+
+  let res = await fetch(u.toString(), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+  });
+
+  if (!res.ok) {
+    const body = new URLSearchParams({
+      grant_type: 'client_credentials',
+      appkey,
+      appsecretkey,
+      scope: 'oob',
+    });
+    res = await fetch(target, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+      },
+      body: body.toString(),
+    });
+  }
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    logDevTokenFail(res.status, text);
+    return null;
+  }
+
+  const json = (await res.json()) as { access_token?: string; error?: string; error_description?: string };
+  const token = json.access_token;
+  if (typeof token === 'string' && token.length > 0) {
+    accessToken = token;
+    logDevTokenOk(token);
+    try {
+      sessionStorage.setItem(STORAGE_KEY, token);
+    } catch {
+      /* ignore */
+    }
+  } else {
+    logDevTokenFail(res.status, JSON.stringify(json));
+  }
+  return accessToken;
+}
+
+export function getLsAccessToken(): string | null {
+  return accessToken;
+}
+
+function scheduleDailySixAmTokenRefresh(): void {
+  if (dailySixAmTimeoutId != null) {
+    clearTimeout(dailySixAmTimeoutId);
+  }
+  dailySixAmTimeoutId = window.setTimeout(() => {
+    void fetchLsAccessToken();
+    scheduleDailySixAmTokenRefresh();
+  }, msUntilNextSixAM());
+}
+
+export function initLsTokenLifecycle(): void {
+  const appkey = import.meta.env.VITE_LS_APP_KEY?.trim();
+  const secret = import.meta.env.VITE_LS_APP_SECRET?.trim();
+  if (!appkey || !secret) {
+    return;
+  }
+
+  if (!accessToken) {
+    void fetchLsAccessToken();
+  }
+
+  scheduleDailySixAmTokenRefresh();
+}

--- a/src/index.css
+++ b/src/index.css
@@ -225,7 +225,7 @@ body {
 .market-index-marquee {
   display: inline-flex;
   width: max-content;
-  animation: market-index-marquee 70s linear infinite;
+  animation: market-index-marquee 220s linear infinite;
   will-change: transform;
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,8 +3,10 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import { initForegroundMessage } from '@/features/fcm/fcmService'
+import { initLsTokenLifecycle } from '@/features/ls/lsTokenScheduler'
 
 initForegroundMessage()
+initLsTokenLifecycle()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/pages/widgets/MarketIndexBar/MarketIndexBar.tsx
+++ b/src/pages/widgets/MarketIndexBar/MarketIndexBar.tsx
@@ -10,25 +10,16 @@ import {
 /** 한 줄에 반복할 스트립 개수 (마퀴 루프용) */
 const STRIP_REPEAT = 8;
 
-function TickerStrip({
-  stripKey,
-  rows,
-  loading,
-}: {
-  stripKey: string;
-  rows: TickerRow[];
-  loading: boolean;
-}) {
+function TickerStrip({ stripKey, rows }: { stripKey: string; rows: TickerRow[] }) {
   return (
     <div className="flex shrink-0 items-center gap-6 px-5 py-2 text-[11px] text-[#4b5563] md:gap-8 md:text-xs">
       {rows.map((item) => {
         const q = item.quote;
         const titleName = (q?.hname && q.hname.trim()) || item.label;
-        const priceStr =
-          loading && !q ? '…' : q != null ? formatPrice(q.price) : '—';
-        const changeStr =
-          loading && !q ? '…' : q != null ? formatChange(q.change) : '—';
-        const pctStr = loading && !q ? '…' : q != null ? `(${formatPct(q.diffPct)})` : '(—)';
+        const pending = !item.loaded && !item.error;
+        const priceStr = pending ? '…' : q != null ? formatPrice(q.price) : '—';
+        const changeStr = pending ? '…' : q != null ? formatChange(q.change) : '—';
+        const pctStr = pending ? '…' : q != null ? `(${formatPct(q.diffPct)})` : '(—)';
         const up = q != null ? isUpQuote(q.sign, q.change) : true;
 
         return (
@@ -63,7 +54,7 @@ function TickerStrip({
 }
 
 export default function MarketIndexBar() {
-  const { rows, loading } = useMarketTickerQuotes();
+  const { rows } = useMarketTickerQuotes();
 
   return (
     <section
@@ -72,10 +63,10 @@ export default function MarketIndexBar() {
     >
       <div className="market-index-marquee">
         {Array.from({ length: STRIP_REPEAT }, (_, i) => (
-          <TickerStrip key={`a-${i}`} stripKey={`a-${i}`} rows={rows} loading={loading} />
+          <TickerStrip key={`a-${i}`} stripKey={`a-${i}`} rows={rows} />
         ))}
         {Array.from({ length: STRIP_REPEAT }, (_, i) => (
-          <TickerStrip key={`b-${i}`} stripKey={`b-${i}`} rows={rows} loading={loading} />
+          <TickerStrip key={`b-${i}`} stripKey={`b-${i}`} rows={rows} />
         ))}
       </div>
     </section>

--- a/src/pages/widgets/MarketIndexBar/MarketIndexBar.tsx
+++ b/src/pages/widgets/MarketIndexBar/MarketIndexBar.tsx
@@ -1,40 +1,82 @@
-/** 한 줄에 반복할 코스피·코스닥 쌍 개수 (넓은 화면에서도 칸이 차도록) */
-const PAIR_REPEAT = 12;
+import {
+  formatChange,
+  formatPct,
+  formatPrice,
+  isUpQuote,
+  useMarketTickerQuotes,
+  type TickerRow,
+} from './useMarketTickerQuotes';
 
-function IndexPair() {
-  return (
-    <div className="flex shrink-0 items-center gap-8 text-xs text-[#4b5563]">
-      <span className="whitespace-nowrap">
-        코스피 <strong className="text-[#111827]">2,690.12</strong>{' '}
-        <span className="text-red-500">+1.24%</span>
-      </span>
-      <span className="whitespace-nowrap">
-        코스닥 <strong className="text-[#111827]">842.31</strong>{' '}
-        <span className="text-blue-500">-0.48%</span>
-      </span>
-    </div>
-  );
-}
+/** 한 줄에 반복할 스트립 개수 (마퀴 루프용) */
+const STRIP_REPEAT = 8;
 
-function TickerSegment({ segmentKey }: { segmentKey: 'a' | 'b' }) {
+function TickerStrip({
+  stripKey,
+  rows,
+  loading,
+}: {
+  stripKey: string;
+  rows: TickerRow[];
+  loading: boolean;
+}) {
   return (
-    <div className="flex shrink-0 items-center gap-8 px-6 py-2">
-      {Array.from({ length: PAIR_REPEAT }, (_, i) => (
-        <IndexPair key={`${segmentKey}-${i}`} />
-      ))}
+    <div className="flex shrink-0 items-center gap-6 px-5 py-2 text-[11px] text-[#4b5563] md:gap-8 md:text-xs">
+      {rows.map((item) => {
+        const q = item.quote;
+        const titleName = (q?.hname && q.hname.trim()) || item.label;
+        const priceStr =
+          loading && !q ? '…' : q != null ? formatPrice(q.price) : '—';
+        const changeStr =
+          loading && !q ? '…' : q != null ? formatChange(q.change) : '—';
+        const pctStr = loading && !q ? '…' : q != null ? `(${formatPct(q.diffPct)})` : '(—)';
+        const up = q != null ? isUpQuote(q.sign, q.change) : true;
+
+        return (
+          <a
+            key={`${stripKey}-${item.id}`}
+            href={item.infoUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group relative z-0 inline-flex items-center whitespace-nowrap px-2 py-0 text-[#4b5563] no-underline transition-colors before:pointer-events-none before:absolute before:inset-x-[-6px] before:inset-y-[-5px] before:-z-10 before:rounded-md before:bg-slate-200/85 before:opacity-0 before:transition-opacity before:content-[''] hover:before:opacity-100"
+            title={`${titleName} · ${item.shcode}`}
+          >
+            <span className="relative z-10">
+              <span className="transition-colors group-hover:text-[#111827]">{item.label}</span>{' '}
+              <strong className="font-semibold text-[#111827] transition-colors group-hover:text-[#0f172a]">
+                {priceStr}
+              </strong>{' '}
+              <span
+                className={
+                  up
+                    ? 'text-red-500 transition-colors group-hover:text-red-600'
+                    : 'text-blue-500 transition-colors group-hover:text-blue-600'
+                }
+              >
+                {changeStr} {pctStr}
+              </span>
+            </span>
+          </a>
+        );
+      })}
     </div>
   );
 }
 
 export default function MarketIndexBar() {
+  const { rows, loading } = useMarketTickerQuotes();
+
   return (
     <section
-      className="hidden min-w-0 w-full shrink-0 overflow-hidden border-t border-[#d8e2f8] bg-white lg:block"
-      aria-label="시장 지수"
+      className="hidden min-w-0 w-full shrink-0 overflow-hidden border-t border-[#d8e2f8] bg-white md:block"
+      aria-label="시장 지수 및 시세"
     >
       <div className="market-index-marquee">
-        <TickerSegment segmentKey="a" />
-        <TickerSegment segmentKey="b" />
+        {Array.from({ length: STRIP_REPEAT }, (_, i) => (
+          <TickerStrip key={`a-${i}`} stripKey={`a-${i}`} rows={rows} loading={loading} />
+        ))}
+        {Array.from({ length: STRIP_REPEAT }, (_, i) => (
+          <TickerStrip key={`b-${i}`} stripKey={`b-${i}`} rows={rows} loading={loading} />
+        ))}
       </div>
     </section>
   );

--- a/src/pages/widgets/MarketIndexBar/marketTickerConfig.ts
+++ b/src/pages/widgets/MarketIndexBar/marketTickerConfig.ts
@@ -1,0 +1,47 @@
+export type MarketTickerDef = {
+  id: string;
+  label: string;
+  shcode: string;
+  /** 신한 SOL ETF 상세 페이지 */
+  infoUrl: string;
+};
+
+/** 하단 마퀴 — LS t1101 시세 · 클릭 시 SOL ETF 안내 URL */
+export const MARKET_TICKER_DEFS: MarketTickerDef[] = [
+  {
+    id: 'sol-200tr',
+    label: 'SOL 200TR',
+    shcode: '295040',
+    infoUrl: 'https://www.soletf.co.kr/ko/fund/etf/210734',
+  },
+  {
+    id: 'sol-kosdaq150',
+    label: 'SOL 코스닥150',
+    shcode: '450910',
+    infoUrl: 'https://www.soletf.co.kr/ko/fund/etf/210961',
+  },
+  {
+    id: 'sol-ai-sobujang',
+    label: 'SOL AI반도체소부장',
+    shcode: '455850',
+    infoUrl: 'https://www.soletf.co.kr/ko/fund/etf/210980',
+  },
+  {
+    id: 'sol-korea-dividend',
+    label: 'SOL 코리아고배당',
+    shcode: '0105E0',
+    infoUrl: 'https://www.soletf.co.kr/ko/fund/etf/211097',
+  },
+  {
+    id: 'sol-smr',
+    label: 'SOL 한국원자력SMR',
+    shcode: '0092B0',
+    infoUrl: 'https://www.soletf.co.kr/ko/fund/etf/211096',
+  },
+  {
+    id: 'sol-ai-top2plus',
+    label: 'SOL AI반도체TOP2플러스',
+    shcode: '0167A0',
+    infoUrl: 'https://www.soletf.co.kr/ko/fund/etf/211106',
+  },
+];

--- a/src/pages/widgets/MarketIndexBar/useMarketTickerQuotes.ts
+++ b/src/pages/widgets/MarketIndexBar/useMarketTickerQuotes.ts
@@ -8,6 +8,8 @@ const POLL_MS = 10 * 60 * 1000;
 export type TickerRow = MarketTickerDef & {
   quote: T1101Quote | null;
   error?: boolean;
+  /** 해당 종목 첫 조회 완료 여부 — 완료 전에는 … 표시 */
+  loaded: boolean;
 };
 
 /** 한국 시세 UI: 상승 빨강 — change·sign 기준 */
@@ -33,42 +35,49 @@ export function formatPct(p: number): string {
 
 export function useMarketTickerQuotes() {
   const [rows, setRows] = useState<TickerRow[]>(() =>
-    MARKET_TICKER_DEFS.map((d) => ({ ...d, quote: null }))
+    MARKET_TICKER_DEFS.map((d) => ({ ...d, quote: null, loaded: false }))
   );
-  const [loading, setLoading] = useState(true);
 
-  const loadAll = useCallback(async () => {
+  const loadAll = useCallback(async (silent: boolean) => {
     const hasKey = Boolean(
       import.meta.env.VITE_LS_APP_KEY?.trim() && import.meta.env.VITE_LS_APP_SECRET?.trim()
     );
     if (!hasKey) {
-      setRows(MARKET_TICKER_DEFS.map((d) => ({ ...d, quote: null, error: true })));
-      setLoading(false);
+      setRows(MARKET_TICKER_DEFS.map((d) => ({ ...d, quote: null, error: true, loaded: true })));
       return;
     }
 
-    setLoading(true);
     await fetchLsAccessToken();
 
-    const results = await Promise.all(
-      MARKET_TICKER_DEFS.map(async (def) => {
+    if (!silent) {
+      setRows(MARKET_TICKER_DEFS.map((d) => ({ ...d, quote: null, error: false, loaded: false })));
+    }
+
+    MARKET_TICKER_DEFS.forEach((def) => {
+      void (async () => {
         try {
           const quote = await fetchT1101Quote(def.shcode);
-          return { ...def, quote, error: !quote } as TickerRow;
+          setRows((prev) =>
+            prev.map((r) =>
+              r.id === def.id ? { ...r, quote, error: !quote, loaded: true } : r
+            )
+          );
         } catch {
-          return { ...def, quote: null, error: true } as TickerRow;
+          setRows((prev) =>
+            prev.map((r) =>
+              r.id === def.id ? { ...r, quote: null, error: true, loaded: true } : r
+            )
+          );
         }
-      })
-    );
-    setRows(results);
-    setLoading(false);
+      })();
+    });
   }, []);
 
   useEffect(() => {
-    void loadAll();
-    const id = window.setInterval(() => void loadAll(), POLL_MS);
+    void loadAll(false);
+    const id = window.setInterval(() => void loadAll(true), POLL_MS);
     return () => window.clearInterval(id);
   }, [loadAll]);
 
-  return { rows, loading, reload: loadAll };
+  return { rows, reload: () => void loadAll(false) };
 }

--- a/src/pages/widgets/MarketIndexBar/useMarketTickerQuotes.ts
+++ b/src/pages/widgets/MarketIndexBar/useMarketTickerQuotes.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useState } from 'react';
+import { fetchLsAccessToken } from '@/features/ls/lsTokenScheduler';
+import { fetchT1101Quote, type T1101Quote } from '@/features/ls/fetchT1101Quote';
+import { MARKET_TICKER_DEFS, type MarketTickerDef } from './marketTickerConfig';
+
+const POLL_MS = 10 * 60 * 1000;
+
+export type TickerRow = MarketTickerDef & {
+  quote: T1101Quote | null;
+  error?: boolean;
+};
+
+/** 한국 시세 UI: 상승 빨강 — change·sign 기준 */
+export function isUpQuote(sign: string, change: number): boolean {
+  if (change > 0) return true;
+  if (change < 0) return false;
+  return sign === '1' || sign === '2';
+}
+
+export function formatPrice(n: number): string {
+  return Math.round(n).toLocaleString('ko-KR');
+}
+
+export function formatChange(change: number): string {
+  if (change === 0) return '0';
+  return change > 0 ? `+${formatPrice(change)}` : formatPrice(change);
+}
+
+export function formatPct(p: number): string {
+  const s = p.toFixed(2);
+  return p > 0 ? `+${s}%` : `${s}%`;
+}
+
+export function useMarketTickerQuotes() {
+  const [rows, setRows] = useState<TickerRow[]>(() =>
+    MARKET_TICKER_DEFS.map((d) => ({ ...d, quote: null }))
+  );
+  const [loading, setLoading] = useState(true);
+
+  const loadAll = useCallback(async () => {
+    const hasKey = Boolean(
+      import.meta.env.VITE_LS_APP_KEY?.trim() && import.meta.env.VITE_LS_APP_SECRET?.trim()
+    );
+    if (!hasKey) {
+      setRows(MARKET_TICKER_DEFS.map((d) => ({ ...d, quote: null, error: true })));
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    await fetchLsAccessToken();
+
+    const results = await Promise.all(
+      MARKET_TICKER_DEFS.map(async (def) => {
+        try {
+          const quote = await fetchT1101Quote(def.shcode);
+          return { ...def, quote, error: !quote } as TickerRow;
+        } catch {
+          return { ...def, quote: null, error: true } as TickerRow;
+        }
+      })
+    );
+    setRows(results);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void loadAll();
+    const id = window.setInterval(() => void loadAll(), POLL_MS);
+    return () => window.clearInterval(id);
+  }, [loadAll]);
+
+  return { rows, loading, reload: loadAll };
+}

--- a/src/pages/widgets/SearchDropdown/StockSearchPanelBody.tsx
+++ b/src/pages/widgets/SearchDropdown/StockSearchPanelBody.tsx
@@ -100,7 +100,7 @@ export function StockSearchPanelBody({
             ref={inputRef}
             value={query}
             onChange={(e) => onQueryChange(e.target.value)}
-            placeholder="종목명 또는 티커 검색"
+            placeholder="종목명 또는 종목코드"
             className="w-full bg-transparent text-sm outline-none"
             autoComplete="off"
           />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,20 @@ export default defineConfig({
         target: 'http://localhost:8080',
         changeOrigin: true,
       },
+      /** LS Open API OAuth (브라우저 CORS 회피) — POST /ls-oauth/oauth2/token */
+      '/ls-oauth': {
+        target: 'https://openapi.ls-sec.co.kr:8080',
+        changeOrigin: true,
+        secure: true,
+        rewrite: (path) => path.replace(/^\/ls-oauth/, ''),
+      },
+      /** LS REST 시세 등 POST /ls-api/stock/market-data (tr_cd 헤더) */
+      '/ls-api': {
+        target: 'https://openapi.ls-sec.co.kr:8080',
+        changeOrigin: true,
+        secure: true,
+        rewrite: (path) => path.replace(/^\/ls-api/, ''),
+      },
     },
   },
 


### PR DESCRIPTION
## #️⃣ Issue Number
- Closes #69 
- 
## 📝 변경사항

LS증권 Open API로 하단 시세 마퀴(MarketIndexBar)에 실시간에 가까운 시세를 붙이고, 지정한 SOL ETF 목록·상세 페이지 링크·UI(속도·호버·모바일 숨김)를 정리했습니다. 브라우저 CORS를 피하기 위해 개발 환경에서 OAuth·시세 REST용 Vite 프록시를 두었습니다.

### 🎯 핵심 변경 사항 (Key Changes)

- [x] **OAuth**: `client_credentials`로 접근 토큰 발급. 공식 문서와 동일하게 쿼리 파라미터 POST 우선, 실패 시 form body 재시도. **매일 로컬 06:00** 갱신 + 최초 부트스트랩 1회. `sessionStorage` 캐시.
- [x] **시세**: `stock/market-data`에 `t1101` 조회, 영문 혼합 종목코드 등은 **`t1901` 폴백**. 종목코드 대문자 정규화.
- [x] **MarketIndexBar**: `marketTickerConfig` 기준 SOL ETF 6종(200TR, 코스닥150, AI반도체소부장, 코리아고배당, 한국원자력SMR, AI반도체TOP2플러스), **신한 SOL ETF 상세 URL** 연결. 전일대비·등락률 표시, 등락 사이 공백.
- [x] **UI**: 마퀴 속도 조정(`index.css` 애니메이션), 호버 시 줄 높이 유지 + `::before`로 칸 강조, **`hidden md:block`**으로 모바일에서 비표시.
- [x] **환경**: `.env.example`에 LS 관련 변수 안내, `vite.config.ts`에 `/ls-api` 프록시 추가.

### 🔍 주안점 & 리뷰 포인트

- **보안**: `VITE_LS_APP_SECRET`은 프론트 번들에 포함될 수 있음. 운영에서는 백엔드에서 토큰·시세 프록시 권장.
- **프로덕션 CORS**: 배포 시 LS 도메인 직접 호출이 막히면 `VITE_LS_MARKET_DATA_URL` 또는 서버 프록시 필요.
- **모바일**: 바는 숨겼지만 `MarketIndexBar`가 마운트되면 훅 폴링은 동작할 수 있음. 모바일에서 API까지 끄려면 추가 분기 검토.

### 🖼️ 스크린샷 / 테스트 결과 (선택 사항)

(로컬에서 `.env.local`에 키 설정 후 하단 마퀴 시세·링크·호버·데스크톱 전용 표시 확인)

---

## 🛠️ PR 유형

- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [x] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [x] 🔧 빌드/패키지 매니저/CI 설정 수정

## 🧪 영향 범위 및 테스트 (Impact & Tests)

### **영향을 받는 모듈/컴포넌트:**

- `src/features/ls/*` (토큰, 시세 URL, t1101/t1901)
- `src/pages/widgets/MarketIndexBar/*`
- `src/main.tsx` (토큰 라이프사이클)
- `vite.config.ts`, `.env.example`

### **테스트 방법:**

- [ ] 단위 테스트 (JUnit/Jest)
- [ ] 통합 테스트
- [ ] 수동 API 테스트 (Postman/Swagger)
- [x] 수동: `npm run dev`, LS 키 설정 후 하단 티커 시세·링크·반응형 동작 확인

## ✅ PR Checklist

- [ ] 커밋 메시지 컨벤션을 준수했습니다.
- [ ] 불필요한 로그나 주석을 제거했습니다.
- [ ] 관련 이슈를 연결했습니다.