### PR TITLE
Feat/86 auth me delete integration

### DIFF
--- a/src/pages/MyPage/components/MyPagePanel.tsx
+++ b/src/pages/MyPage/components/MyPagePanel.tsx
@@ -13,7 +13,10 @@ import WithdrawConfirmModal from './WithdrawConfirmModal';
 
 export interface MyPagePanelProps {
   onClose: () => void;
-  onLogout: () => void;
+  onLogout: () => Promise<void>;
+  onWithdraw: () => Promise<void>;
+  withdrawMessage?: string;
+  withdrawMessageType?: 'success' | 'error' | '';
 }
 
 const TABS: { key: MyPageTabKey; label: string }[] = [
@@ -23,7 +26,7 @@ const TABS: { key: MyPageTabKey; label: string }[] = [
   { key: 'settings', label: '설정' },
 ];
 
-export default function MyPagePanel({ onClose, onLogout }: MyPagePanelProps) {
+export default function MyPagePanel({ onClose, onLogout, onWithdraw, withdrawMessage = '', withdrawMessageType = '', }: MyPagePanelProps) {
   const navigate = useNavigate();
   const { user, nickname, refreshAuth, clearAuth } = useAuth();
 
@@ -35,12 +38,13 @@ export default function MyPagePanel({ onClose, onLogout }: MyPagePanelProps) {
   const [isEditingNickname, setIsEditingNickname] = useState(false);
   const [nicknameDraft, setNicknameDraft] = useState('');
   const [isSavingNickname, setIsSavingNickname] = useState(false);
+  const [isWithdrawing, setIsWithdrawing] = useState(false);
   const [nicknameMessage, setNicknameMessage] = useState('');
   const [nicknameMessageType, setNicknameMessageType] = useState<'success' | 'error' | ''>('');
 
   const displayNickname = nickname || user?.nickname || '사용자';
   const displayEmail = user?.email || '';
-  const profileInitial = Array.from(displayNickname.trim())[0] ?? '유';
+  const profileInitial = Array.from(displayNickname.trim())[0] ?? '닉';
 
   useEffect(() => {
     setNicknameDraft(displayNickname);
@@ -109,6 +113,17 @@ export default function MyPagePanel({ onClose, onLogout }: MyPagePanelProps) {
     setIsEditingNickname(false);
     setNicknameMessage('');
     setNicknameMessageType('');
+  };
+
+  const handleConfirmWithdraw = async () => {
+    if (isWithdrawing) return;
+    try {
+      setIsWithdrawing(true);
+      setShowWithdrawModal(false);
+      await onWithdraw();
+    } finally {
+      setIsWithdrawing(false);
+    }
   };
 
   const panel = (
@@ -259,7 +274,7 @@ export default function MyPagePanel({ onClose, onLogout }: MyPagePanelProps) {
               <div className="hidden shrink-0 flex-col items-center gap-2 border-t border-[#eff1f8] px-[21px] pt-6 pb-4 md:flex">
                 <button
                     type="button"
-                    onClick={onLogout}
+                    onClick={() => void onLogout()}
                     className="w-full cursor-pointer overflow-hidden rounded-lg border-0 bg-transparent p-0 shadow-none"
                 >
                   <img src={logoutButtonImg} alt="로그아웃" className="block h-auto w-full" width={348} height={37} />
@@ -271,13 +286,24 @@ export default function MyPagePanel({ onClose, onLogout }: MyPagePanelProps) {
                 >
                   회원 탈퇴
                 </button>
+
+                {withdrawMessage && (
+                    <p
+                        className={`text-[11px] ${
+                            withdrawMessageType === 'error' ? 'text-[#dc2626]' : 'text-[#059669]'
+                        }`}
+                    >
+                      {withdrawMessage}
+                    </p>
+                )}
+
               </div>
           )}
           {activeTab === 'settings' && (
               <div className="flex shrink-0 flex-col items-center gap-2 border-t border-[#eff1f8] px-[21px] pt-6 pb-4 md:hidden">
                 <button
                     type="button"
-                    onClick={onLogout}
+                    onClick={() => void onLogout()}
                     className="w-full cursor-pointer overflow-hidden rounded-lg border-0 bg-transparent p-0 shadow-none"
                 >
                   <img src={logoutButtonImg} alt="로그아웃" className="block h-auto w-full" width={348} height={37} />
@@ -289,6 +315,17 @@ export default function MyPagePanel({ onClose, onLogout }: MyPagePanelProps) {
                 >
                   회원 탈퇴
                 </button>
+
+                {withdrawMessage && (
+                    <p
+                        className={`text-[11px] ${
+                            withdrawMessageType === 'error' ? 'text-[#dc2626]' : 'text-[#059669]'
+                        }`}
+                    >
+                      {withdrawMessage}
+                    </p>
+                )}
+
               </div>
           )}
         </div>
@@ -296,7 +333,7 @@ export default function MyPagePanel({ onClose, onLogout }: MyPagePanelProps) {
         <WithdrawConfirmModal
             open={showWithdrawModal}
             onClose={() => setShowWithdrawModal(false)}
-            onConfirmWithdraw={onLogout}
+            onConfirmWithdraw={handleConfirmWithdraw}
         />
       </>
   );

--- a/src/pages/MyPage/components/WithdrawConfirmModal.tsx
+++ b/src/pages/MyPage/components/WithdrawConfirmModal.tsx
@@ -8,80 +8,73 @@ export interface WithdrawConfirmModalProps {
 }
 
 export default function WithdrawConfirmModal({ open, onClose, onConfirmWithdraw }: WithdrawConfirmModalProps) {
-  const [pwInput, setPwInput] = useState('');
   const [agreedDelete, setAgreedDelete] = useState(false);
 
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-[400] flex items-center justify-center bg-black/35 px-4" role="presentation">
-      <div
-        className="relative w-full max-w-[400px] rounded-2xl bg-white px-9 pb-7 pt-9 shadow-2xl"
-        role="dialog"
-        aria-labelledby="withdraw-title"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <button
-          type="button"
-          onClick={onClose}
-          className="absolute right-4 top-4 flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent text-lg text-[#9ca3af]"
-          aria-label="닫기"
+      <div className="fixed inset-0 z-[400] flex items-center justify-center bg-black/35 px-4" role="presentation">
+        <div
+            className="relative w-full max-w-[400px] rounded-2xl bg-white px-9 pb-7 pt-9 shadow-2xl"
+            role="dialog"
+            aria-labelledby="withdraw-title"
+            onClick={(e) => e.stopPropagation()}
         >
-          ✕
-        </button>
-        <div className="mb-2.5 flex justify-center" aria-hidden>
-          <img src={logoSad} alt="" className="h-16 w-auto" />
-        </div>
-        <h3 id="withdraw-title" className="mb-2.5 text-center text-xl font-bold text-[#111827]">
-          정말 탈퇴하시겠어요?
-        </h3>
-        <p className="mb-5 text-center text-[13px] leading-relaxed text-[#6b7280]">
-          계정을 삭제하면 모든 데이터가 영구적으로 삭제됩니다.
-          <br />
-          이 작업은 되돌릴 수 없습니다.
-        </p>
-        <div className="mb-3">
-          <label htmlFor="withdraw-pw" className="mb-1.5 block text-[13px] font-medium text-[#374151]">
-            비밀번호 확인
-          </label>
-          <input
-            id="withdraw-pw"
-            type="password"
-            value={pwInput}
-            onChange={(e) => setPwInput(e.target.value)}
-            placeholder="현재 비밀번호 입력"
-            className="w-full rounded-lg border border-[#e5e7eb] px-3 py-2.5 text-sm outline-none focus:border-[#3b82f6]"
-          />
-        </div>
-        <label className="mb-5 flex cursor-pointer items-start gap-2">
-          <input
-            type="checkbox"
-            checked={agreedDelete}
-            onChange={(e) => setAgreedDelete(e.target.checked)}
-            className="mt-0.5 h-3.5 w-3.5 accent-primary"
-          />
-          <span className="text-xs text-[#6b7280]">
-            계정 삭제 시 모든 데이터가 삭제되는 것을 이해했습니다.
+          <button
+              type="button"
+              onClick={onClose}
+              className="absolute right-4 top-4 flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent text-lg text-[#9ca3af]"
+              aria-label="닫기"
+          >
+            ✕
+          </button>
+
+          <div className="mb-2.5 flex justify-center" aria-hidden>
+            <img src={logoSad} alt="" className="h-16 w-auto" />
+          </div>
+
+          <h3 id="withdraw-title" className="mb-2.5 text-center text-xl font-bold text-[#111827]">
+            정말 탈퇴하시겠어요?
+          </h3>
+
+          <p className="mb-5 text-center text-[13px] leading-relaxed text-[#6b7280]">
+            계정을 삭제하면 모든 데이터가 영구적으로 삭제됩니다.
+            <br />
+            이 작업은 되돌릴 수 없습니다.
+          </p>
+
+          <label className="mb-5 flex cursor-pointer items-start gap-2">
+            <input
+                type="checkbox"
+                checked={agreedDelete}
+                onChange={(e) => setAgreedDelete(e.target.checked)}
+                className="mt-0.5 h-3.5 w-3.5 accent-primary"
+            />
+            <span className="text-xs text-[#6b7280]">
+            위 내용을 확인했으며, 계정 삭제에 동의합니다.
           </span>
-        </label>
-        <button
-          type="button"
-          className="mb-2.5 w-full cursor-pointer rounded-lg border-0 bg-primary py-3 text-[15px] font-bold text-white"
-          onClick={() => {
-            onClose();
-            onConfirmWithdraw();
-          }}
-        >
-          계정 탈퇴
-        </button>
-        <button
-          type="button"
-          onClick={onClose}
-          className="w-full cursor-pointer rounded-lg border-0 bg-[#f3f4f6] py-3 text-[15px] font-medium text-[#374151]"
-        >
-          취소
-        </button>
+          </label>
+
+          <button
+              type="button"
+              disabled={!agreedDelete}
+              className="mb-2.5 w-full rounded-lg border-0 bg-primary py-3 text-[15px] font-bold text-white disabled:cursor-not-allowed disabled:opacity-50"
+              onClick={() => {
+                onClose();
+                onConfirmWithdraw();
+              }}
+          >
+            계정 탈퇴
+          </button>
+
+          <button
+              type="button"
+              onClick={onClose}
+              className="w-full cursor-pointer rounded-lg border-0 bg-[#f3f4f6] py-3 text-[15px] font-medium text-[#374151]"
+          >
+            취소
+          </button>
+        </div>
       </div>
-    </div>
   );
 }

--- a/src/shared/components/layout/Header.tsx
+++ b/src/shared/components/layout/Header.tsx
@@ -13,7 +13,7 @@ import SignupModal from "@/features/auth/components/SignupModal";
 import MyPagePanel from "@/pages/MyPage/components/MyPagePanel";
 import AlertCenter from "@/features/alert/AlertCenter/AlertCenter";
 import { alertCenterListHasUnread } from "@/features/alert/AlertCenter/alertCenter.mock";
-import { logoutFromServer } from "@/features/auth/api/authApi";
+import { deleteMyAccount, getApiResponseCode, logoutFromServer } from '@/features/auth/api/authApi';
 
 
 type HeaderProps = {
@@ -36,6 +36,8 @@ export default function Header({ onMyPageOpen, disableMyPagePanel = false }: Hea
   const desktopAlertContainerRef = useRef<HTMLDivElement | null>(null);
 
   const hasUnread = alertCenterListHasUnread(allListMarkedRead, detailFullyReadIds);
+  const [withdrawMessage, setWithdrawMessage] = useState('');
+  const [withdrawMessageType, setWithdrawMessageType] = useState<'success' | 'error' | ''>('');
 
   const renderAlertButton = (
     anchor: "mobile" | "desktop",
@@ -137,13 +139,15 @@ export default function Header({ onMyPageOpen, disableMyPagePanel = false }: Hea
               <>
                 {renderAlertButton("desktop", desktopAlertContainerRef, "w-8.5 h-8.5")}
                 <button
-                  onClick={() => {
-                    if (onMyPageOpen) {
-                      onMyPageOpen();
-                      return;
-                    }
-                    setMyPageOpen(true);
-                  }}
+                    onClick={() => {
+                        if (onMyPageOpen) {
+                            onMyPageOpen();
+                            return;
+                        }
+                        setWithdrawMessage('');
+                        setWithdrawMessageType('');
+                        setMyPageOpen(true);
+                    }}
                   className="w-8.5 h-8.5 rounded-full flex items-center justify-center text-white text-xs font-bold bg-primary"
                 >
                   {profileInitial}
@@ -189,18 +193,52 @@ export default function Header({ onMyPageOpen, disableMyPagePanel = false }: Hea
       )}
       <MobileSearchSheet open={mobileSearchOpen} onClose={() => setMobileSearchOpen(false)} />
       {!disableMyPagePanel && isLoggedIn && myPageOpen && (
-        <MyPagePanel
-          onClose={() => setMyPageOpen(false)}
-          onLogout={async () => {
-              try {
-                  await logoutFromServer();
-              } finally {
-                  clearAuth();
+          <MyPagePanel
+              onClose={() => {
                   setMyPageOpen(false);
-                  navigate(ROUTES.HOME);
-              }
-          }}
-        />
+                  setWithdrawMessage('');
+                  setWithdrawMessageType('');
+              }}
+              onLogout={async () => {
+                  try {
+                      await logoutFromServer();
+                  } finally {
+                      clearAuth();
+                      setMyPageOpen(false);
+                      navigate(ROUTES.HOME);
+                  }
+              }}
+              onWithdraw={async () => {
+                  try {
+                      await deleteMyAccount();
+                      clearAuth();
+                      setMyPageOpen(false);
+                      navigate('/login');
+                  } catch (error: unknown) {
+                      const code = getApiResponseCode(error);
+
+                      if (code === 2952) {
+                          setWithdrawMessage('로그인이 필요합니다.');
+                          setWithdrawMessageType('error');
+                          clearAuth();
+                          setMyPageOpen(false);
+                          navigate('/login');
+                          return;
+                      }
+
+                      if (code === 4013) {
+                          setWithdrawMessage('이미 탈퇴한 계정입니다.');
+                          setWithdrawMessageType('error');
+                          return;
+                      }
+
+                      setWithdrawMessage('회원 탈퇴 중 오류가 발생했습니다.');
+                      setWithdrawMessageType('error');
+                  }
+              }}
+              withdrawMessage={withdrawMessage}
+              withdrawMessageType={withdrawMessageType}
+          />
       )}
     </>
   );

--- a/src/shared/components/layout/MobileLayout.tsx
+++ b/src/shared/components/layout/MobileLayout.tsx
@@ -6,7 +6,7 @@ import { ROUTES } from '@/shared/constants/routes';
 import MyPagePanel from '@/pages/MyPage/components/MyPagePanel';
 import Header from './Header';
 import BottomTabBar from './BottomTabBar';
-import { logoutFromServer } from '@/features/auth/api/authApi';
+import { deleteMyAccount, getApiResponseCode, logoutFromServer } from '@/features/auth/api/authApi';
 
 
 /** 홈 등 내부에서 높이·스크롤을 쓰려면 main은 스크롤 금지 + min-h-0 (padding 없음) */
@@ -18,6 +18,9 @@ export default function MobileLayout({
   const navigate = useNavigate();
   const { isLoggedIn, clearAuth } = useAuth();
   const [myPageOpen, setMyPageOpen] = useState(false);
+  const [withdrawMessage, setWithdrawMessage] = useState('');
+  const [withdrawMessageType, setWithdrawMessageType] = useState<'success' | 'error' | ''>('');
+
 
   const openMyPage = () => {
     if (!isLoggedIn) {
@@ -33,18 +36,53 @@ export default function MobileLayout({
       <main className="flex min-h-0 flex-1 flex-col overflow-hidden">{content}</main>
       <BottomTabBar onMyPageOpen={openMyPage} myPageActive={myPageOpen} />
       {isLoggedIn && myPageOpen && (
-        <MyPagePanel
-          onClose={() => setMyPageOpen(false)}
-          onLogout={async () => {
-            try {
-              await logoutFromServer();
-            } finally {
-              clearAuth();
-              setMyPageOpen(false);
-              navigate(ROUTES.HOME);
-            }
-          }}
-        />
+          <MyPagePanel
+              onClose={() => {
+                setMyPageOpen(false);
+                setWithdrawMessage('');
+                setWithdrawMessageType('');
+              }}
+              onLogout={async () => {
+                try {
+                  await logoutFromServer();
+                } finally {
+                  clearAuth();
+                  setMyPageOpen(false);
+                  navigate(ROUTES.HOME);
+                }
+              }}
+              onWithdraw={async () => {
+                try {
+                  await deleteMyAccount();
+                  clearAuth();
+                  setMyPageOpen(false);
+                  navigate('/login');
+                } catch (error: unknown) {
+                  const code = getApiResponseCode(error);
+
+                  if (code === 2952) {
+                    setWithdrawMessage('로그인이 필요합니다.');
+                    setWithdrawMessageType('error');
+                    clearAuth();
+                    setMyPageOpen(false);
+                    navigate('/login');
+                    return;
+                  }
+
+                  if (code === 4013) {
+                    setWithdrawMessage('이미 탈퇴한 계정입니다.');
+                    setWithdrawMessageType('error');
+                    return;
+                  }
+
+                  setWithdrawMessage('회원 탈퇴 중 오류가 발생했습니다.');
+                  setWithdrawMessageType('error');
+                }
+              }}
+              withdrawMessage={withdrawMessage}
+              withdrawMessageType={withdrawMessageType}
+          />
+
       )}
     </div>
   );


### PR DESCRIPTION
## #️⃣ Issue Number
<!--- ex) #이슈번호, #이슈번호 -->
- Closes #86 
## 📝 변경사항
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 마이페이지에서 로그아웃과 회원 탈퇴 동작이 섞여 있던 구조를 분리
- 탈퇴 확인 모달의 confirm 액션을 별도 onWithdraw 흐름으로 연결해 DELETE /auth/me를 호출하도록 변경했고, 로그아웃은 기존 동작을 유지
- 탈퇴 모달에서 비밀번호 입력 UI를 제거하고, 안내 문구 + 동의 체크 기반으로만 진행되도록 정리
- 
### 🎯 핵심 변경 사항 (Key Changes)

- [ ] `MyPagePanel` props 확장: `onWithdraw`, `withdrawMessage`, `withdrawMessageType`
- [ ]  `WithdrawConfirmModal` confirm 동작을 `onLogout`에서 `onWithdraw`로 분리
- [ ]  `Header`, `MobileLayout`에서 `onWithdraw` 구현 (`deleteMyAccount -> clearAuth -> close -> /login`)
- [ ]  탈퇴 실패 코드 분기 처리
- [ ]  `2952`: `로그인이 필요합니다.`
- [ ]  `4013`: `이미 탈퇴한 계정입니다.`
- [ ]  기본: 회원 탈퇴 중 오류가 발생했습니다.
- [ ]  탈퇴 모달 비밀번호 입력 제거
- [ ]  탈퇴 모달은 안내 문구 + 동의 체크 후에만 진행 가능하도록 수정


### 🔍 주안점 & 리뷰 포인트
<!--
  (Optional)
  리뷰 시에 유심히 봐주었으면 하는 부분 설명
-->
<!-- 
  - 예: 멀티 모듈 구조에서 의존성 주입 방식이 적절한지 봐주세요.
  - 예: Next.js App Router의 `params` 언래핑(unwrap) 처리가 올바른지 확인 부탁드립니다.
-->

### 🖼️ 스크린샷 / 테스트 결과 (선택 사항)
<!--
  (Optional)
  작업 결과 만들거나 변경된 화면 스크린샷
  테스트 수행 결과 스크린샷
-->
---
수동 확인:
로그아웃 버튼: 기존 경로(HOME) 이동
회원 탈퇴 버튼: 모달 동의 체크 후 탈퇴 요청

## 🛠️ PR 유형
- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [x] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## 🧪 영향 범위 및 테스트 (Impact & Tests)
<!--
  (Optional)
  작업에 의해 영향을 받은 모듈/컴포넌트 설명
  수행한 테스트 설명
-->
### **영향을 받는 모듈/컴포넌트:** 
<!--
  (예: `core-api`, `domain-blog`)
-->
- `src/pages/MyPage/components/MyPagePanel.tsx`
- `src/shared/components/layout/Header.tsx`
- `src/shared/components/layout/MobileLayout.tsx`
- `src/pages/MyPage/components/WithdrawConfirmModal.tsx`
### **테스트 방법:**
- [ ] 단위 테스트 (JUnit/Jest)
- [ ] 통합 테스트
- [x] 수동 API 테스트 

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 불필요한 로그나 주석을 제거했습니다.
- [x] 관련 이슈를 연결했습니다.
