### PR TITLE
[Feat] notification api 연동

### DIFF
--- a/src/features/alert/AlertCenter/AlertCenter.tsx
+++ b/src/features/alert/AlertCenter/AlertCenter.tsx
@@ -1,41 +1,30 @@
 import { useEffect, useState, type RefObject } from 'react';
-import { ALERT_CENTER_NOTIFICATION_LIST, alertCenterListFullyRead } from './alertCenter.mock';
 import AlertCenterDetailFeed from './AlertCenterDetailFeed';
-import {
-  formatDaysAgoLabel,
-  formatNotifiedDateTitle,
-  stockNamesSubtitle,
-} from './alertCenterFormatters';
 import bellAlarmSrc from '@/assets/Bell_alarm.svg';
+import { useNotificationSummary } from '../hooks/useNotificationSummary';
+import { useMarkNotificationRead, useMarkAllNotificationsRead } from '../hooks/useNotificationMutations';
 
 export type AlertCenterTab = 'all' | 'detail';
 
 export interface AlertCenterProps {
   onClose: () => void;
   containerRef: RefObject<HTMLElement | null>;
-  allListMarkedRead: boolean;
-  onAllListMarkedRead: () => void;
-  detailFullyReadIds: ReadonlySet<number>;
-  onNotificationDetailFullyRead: (notificationId: number) => void;
 }
 
 const PANEL_CLASS =
   'flex h-[581px] max-h-[min(581px,85vh)] w-[380px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-[14px] border border-[#e5e7eb] bg-white shadow-[0_8px_32px_rgba(0,0,0,0.1)] max-md:fixed max-md:left-0 max-md:right-0 max-md:top-[55px] max-md:mt-0 max-md:h-[calc(100dvh-55px)] max-md:max-h-none max-md:w-screen max-md:max-w-none max-md:translate-x-0 max-md:rounded-none max-md:border-x-0 max-md:border-b-0 max-md:shadow-none';
 
-export default function AlertCenter({
-  onClose,
-  containerRef,
-  allListMarkedRead,
-  onAllListMarkedRead,
-  detailFullyReadIds,
-  onNotificationDetailFullyRead,
-}: AlertCenterProps) {
+export default function AlertCenter({ onClose, containerRef }: AlertCenterProps) {
   const [tab, setTab] = useState<AlertCenterTab>('all');
   const [selectedNotificationId, setSelectedNotificationId] = useState<number | null>(null);
 
-  const firstListId = ALERT_CENTER_NOTIFICATION_LIST[0]?.notificationId ?? null;
+  const { data: summaryList, isLoading } = useNotificationSummary(7);
+  const { mutate: markRead } = useMarkNotificationRead();
+  const { mutate: markAllRead } = useMarkAllNotificationsRead();
+
+  const firstListId = summaryList[0]?.notificationId ?? null;
   const effectiveDetailId = selectedNotificationId ?? firstListId;
-  const listFullyRead = alertCenterListFullyRead(allListMarkedRead, detailFullyReadIds);
+  const listFullyRead = summaryList.length > 0 && summaryList.every((item) => item.isRead);
 
   useEffect(() => {
     function handleMouseDown(e: MouseEvent) {
@@ -73,10 +62,7 @@ export default function AlertCenter({
             <button
               type="button"
               className="mypage-scrap-kr shrink-0 border-0 bg-transparent p-0 text-[11.5px] font-bold leading-tight text-[#014d9d]"
-              onClick={() => {
-                onAllListMarkedRead();
-                // TODO: PATCH /api/notifications/read — body { notificationIds: [] }
-              }}
+              onClick={() => markAllRead()}
             >
               전체 읽음 처리
             </button>
@@ -112,34 +98,40 @@ export default function AlertCenter({
       <div className="min-h-0 flex-1 overflow-hidden">
         {tab === 'all' ? (
           <div className="scrollbar-hide h-full overflow-y-auto">
-            {ALERT_CENTER_NOTIFICATION_LIST.map((item) => (
+            {isLoading && (
+              <div className="mypage-scrap-kr flex min-h-[120px] items-center justify-center text-[13px] text-[#9ca3af]">
+                불러오는 중...
+              </div>
+            )}
+            {!isLoading && summaryList.length === 0 && (
+              <div className="mypage-scrap-kr flex min-h-[120px] items-center justify-center text-[13px] text-[#9ca3af]">
+                최근 알림이 없습니다.
+              </div>
+            )}
+            {summaryList.map((item) => (
               <button
                 key={item.notificationId}
                 type="button"
                 onClick={() => {
+                  markRead(item.notificationId);
                   setSelectedNotificationId(item.notificationId);
                   setTab('detail');
                 }}
                 className={`mypage-scrap-kr flex h-[81px] min-h-[81px] w-full shrink-0 cursor-pointer items-center gap-3 border-b border-[#f3f4f6] px-[18px] text-left transition-colors hover:bg-[#F0F2F8] ${
-                  allListMarkedRead || detailFullyReadIds.has(item.notificationId) ? 'bg-[#F0F2F8]' : ''
-                } ${
-                  !allListMarkedRead &&
-                  !detailFullyReadIds.has(item.notificationId) &&
-                  item.isRead
-                    ? 'opacity-90'
-                    : ''
+                  item.isRead ? 'bg-[#F0F2F8]' : ''
                 }`}
               >
                 <div className="flex h-9 w-9 shrink-0 -translate-y-1 items-center justify-center rounded-lg bg-[#f3f4f6]">
                   <img src={bellAlarmSrc} alt="" aria-hidden className="h-6 w-6" />
                 </div>
                 <div className="min-w-0 flex-1">
-                  <div className="text-[13px] font-bold leading-snug text-[#111827]">
-                    {formatNotifiedDateTitle(item.notifiedDate)}
+                  <div className="text-[12px] leading-snug text-[#111827]">
+                    {item.message.split(/\*\*(.*?)\*\*/g).map((part, i) =>
+                      i % 2 === 1 ? <strong key={i}>{part}</strong> : part
+                    )}
                   </div>
-                  <div className="mt-0.5 text-[12px] leading-snug text-[#6b7280]">{stockNamesSubtitle(item.stocks)}</div>
                   <div className="mt-1 text-[11px] leading-snug text-[#9ca3af]">
-                    {formatDaysAgoLabel(item.daysAgo)}
+                    {item.relativeTime}
                   </div>
                 </div>
               </button>
@@ -147,10 +139,7 @@ export default function AlertCenter({
           </div>
         ) : (
           <div className="scrollbar-faint h-full overflow-y-auto overflow-x-hidden">
-            <AlertCenterDetailFeed
-              notificationId={effectiveDetailId}
-              onNotificationDetailFullyRead={onNotificationDetailFullyRead}
-            />
+            <AlertCenterDetailFeed notificationId={effectiveDetailId} />
           </div>
         )}
       </div>

--- a/src/features/alert/AlertCenter/AlertCenterDetailFeed.tsx
+++ b/src/features/alert/AlertCenter/AlertCenterDetailFeed.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useMemo, useState } from 'react';
 import type { AlertItemRow, AlertTag } from './alertCenter.types';
 import { isTodayNotifiedDate, notificationDetailToAlertGroups } from './alertCenterDetailAdapter';
 import AlertStockAvatar from './AlertStockAvatar';
@@ -29,7 +29,7 @@ function EventContent({ item }: { item: AlertItemRow }) {
       {item.tags && item.tags.length > 0 && (
         <div className="mt-2 flex flex-wrap gap-1.5">
           {item.tags.map((tag) => (
-            <TagChip key={`${item.headline}-$#{tag.label}`} tag={tag} />
+            <TagChip key={`${item.headline}-${tag.label}`} tag={tag} />
           ))}
         </div>
       )}
@@ -41,14 +41,9 @@ const PX = 18;
 
 export interface AlertCenterDetailFeedProps {
   notificationId: number | null;
-  onNotificationDetailFullyRead?: (notificationId: number) => void;
 }
 
-export default function AlertCenterDetailFeed({
-  notificationId,
-  onNotificationDetailFullyRead,
-}: AlertCenterDetailFeedProps) {
-  const [readStateByGroup, setReadStateByGroup] = useState<Record<string, boolean>>({});
+export default function AlertCenterDetailFeed({ notificationId }: AlertCenterDetailFeedProps) {
   const [collapsedByGroup, setCollapsedByGroup] = useState<Record<string, boolean>>({});
   const { data: allDetails } = useNotificationDetail({ days: 7 });
 
@@ -62,28 +57,7 @@ export default function AlertCenterDetailFeed({
     return [{ date: detail.date, isToday: isTodayNotifiedDate(detail.date), groups }];
   }, [detail]);
 
-  const allGroupKeys = useMemo(() => {
-    const keys: string[] = [];
-    for (const s of sections) {
-      s.groups.forEach((g) => keys.push(`${s.date}-${g.code}`));
-    }
-    return keys;
-  }, [sections]);
-
-  const isAllRead = allGroupKeys.length > 0 && allGroupKeys.every((k) => readStateByGroup[k]);
   const getGroupKey = (date: string, code: string) => `${date}-${code}`;
-
-  const detailNotifyRef = useRef<number | null>(null);
-  useEffect(() => {
-    detailNotifyRef.current = null;
-  }, [notificationId]);
-
-  useEffect(() => {
-    if (notificationId == null || allGroupKeys.length === 0 || !isAllRead) return;
-    if (detailNotifyRef.current === notificationId) return;
-    detailNotifyRef.current = notificationId;
-    onNotificationDetailFullyRead?.(notificationId);
-  }, [notificationId, isAllRead, allGroupKeys.length, onNotificationDetailFullyRead]);
 
   if (sections.length === 0) {
     return (
@@ -96,7 +70,7 @@ export default function AlertCenterDetailFeed({
   return (
     <div className="mypage-scrap-kr w-full overflow-x-hidden pt-4 pb-4" style={{ paddingLeft: PX, paddingRight: PX }}>
       <div className="flex flex-col gap-4">
-        {sections.map(({ date, isToday, groups }, dateIdx) => (
+        {sections.map(({ date, isToday, groups }) => (
           <section key={date} className="flex flex-col gap-0">
             <div
               className="flex items-center justify-between gap-3 border-b border-[#e5e7eb] pb-2.5"
@@ -110,25 +84,6 @@ export default function AlertCenterDetailFeed({
                   </span>
                 )}
               </div>
-              {dateIdx === 0 && (
-                <button
-                  type="button"
-                  onClick={() =>
-                    setReadStateByGroup(() => {
-                      const next: Record<string, boolean> = {};
-                      allGroupKeys.forEach((k) => {
-                        next[k] = true;
-                      });
-                      return next;
-                    })
-                  }
-                  className={`shrink-0 translate-x-2 border-0 bg-transparent p-0 text-[11.5px] font-bold ${
-                    isAllRead ? 'text-[#9ca3af]' : 'text-[#014d9d]'
-                  }`}
-                >
-                  {isAllRead ? '전체 읽음' : '전체 읽음 처리'}
-                </button>
-              )}
             </div>
 
             <div className="relative flex flex-col">
@@ -136,8 +91,7 @@ export default function AlertCenterDetailFeed({
                 <Fragment key={`${group.code}-${date}-${idx}`}>
                   {(() => {
                     const groupKey = getGroupKey(date, group.code);
-                    const isRead = !!readStateByGroup[groupKey];
-                    const isCollapsed = collapsedByGroup[groupKey] !== false; // 기본 접힘
+                    const isCollapsed = collapsedByGroup[groupKey] !== false;
                     return (
                       <>
                         <div className="relative z-10 border-b border-[#f3f4f6] last:border-b-0">
@@ -151,15 +105,7 @@ export default function AlertCenterDetailFeed({
                             }
                           >
                             <div className="relative shrink-0">
-                              <AlertStockAvatar color={group.color} ini={group.ini} />
-                              {!isRead && (
-                                <span
-                                  className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[9px] font-bold text-white shadow-sm"
-                                  style={{ backgroundColor: group.badgeColor }}
-                                >
-                                  {group.items.length}
-                                </span>
-                              )}
+                              <AlertStockAvatar color={group.color} ini={group.ini} logoUrl={group.logoUrl} />
                             </div>
 
                             <div className="min-w-0 flex-1">
@@ -189,53 +135,31 @@ export default function AlertCenterDetailFeed({
                         </div>
 
                         {!isCollapsed && (
-                          <>
-                            <div
-                              className={`relative z-10 border-b border-[#f3f4f6] last:border-b-0 ${
-                                isRead ? 'bg-[#F0F2F8]' : 'bg-white'
-                              }`}
-                              style={{ marginLeft: -PX, marginRight: -PX, paddingLeft: PX, paddingRight: PX }}
-                            >
-                              <div className="relative flex flex-col">
-                                <div className="absolute top-0 bottom-0 left-[-2px] z-30 w-[2px] bg-[#D8E2F8]" aria-hidden />
-                                {group.items.map((item, itemIdx) => (
-                                  <div
-                                    key={`${group.code}-${itemIdx}`}
-                                    className="relative -mx-[18px] flex w-[calc(100%+36px)] items-stretch gap-2.5 px-[18px] py-2 transition-colors hover:bg-[#F0F2F8]"
-                                  >
-                                    <div className="flex w-4 shrink-0 flex-col items-center">
-                                      <span
-                                        className="relative z-30 -ml-[17px] mt-1 h-1.5 w-1.5 shrink-0 rounded-full ring-3 ring-white"
-                                        style={{ backgroundColor: item.dotColor }}
-                                        aria-hidden
-                                      />
-                                    </div>
-                                    <div className="min-w-0 flex-1">
-                                      <EventContent item={item} />
-                                    </div>
+                          <div
+                            className="relative z-10 border-b border-[#f3f4f6] last:border-b-0 bg-white"
+                            style={{ marginLeft: -PX, marginRight: -PX, paddingLeft: PX, paddingRight: PX }}
+                          >
+                            <div className="relative flex flex-col">
+                              <div className="absolute top-0 bottom-0 left-[-2px] z-30 w-[2px] bg-[#D8E2F8]" aria-hidden />
+                              {group.items.map((item, itemIdx) => (
+                                <div
+                                  key={`${group.code}-${itemIdx}`}
+                                  className="relative -mx-[18px] flex w-[calc(100%+36px)] items-stretch gap-2.5 px-[18px] py-2 transition-colors hover:bg-[#F0F2F8]"
+                                >
+                                  <div className="flex w-4 shrink-0 flex-col items-center">
+                                    <span
+                                      className="relative z-30 -ml-[17px] mt-1 h-1.5 w-1.5 shrink-0 rounded-full ring-3 ring-white"
+                                      style={{ backgroundColor: item.dotColor }}
+                                      aria-hidden
+                                    />
                                   </div>
-                                ))}
-                              </div>
+                                  <div className="min-w-0 flex-1">
+                                    <EventContent item={item} />
+                                  </div>
+                                </div>
+                              ))}
                             </div>
-                            <div
-                              className="relative z-10 flex items-center justify-between gap-3 border-y border-[#f3f4f6] bg-[#F0F2F8] py-2.5"
-                              style={{ marginLeft: -PX, marginRight: -PX, paddingLeft: PX, paddingRight: PX }}
-                            >
-                              <span className="text-[12px] font-medium text-[#6b7280]">총 {group.items.length}건</span>
-                              <button
-                                type="button"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  setReadStateByGroup((prev) => ({ ...prev, [groupKey]: true }));
-                                }}
-                                className={`shrink-0 border-0 bg-transparent p-0 text-[11.5px] font-bold ${
-                                  isRead ? 'text-[#9ca3af]' : 'text-[#014d9d]'
-                                }`}
-                              >
-                                {isRead ? '읽음' : '읽음 처리'}
-                              </button>
-                            </div>
-                          </>
+                          </div>
                         )}
                       </>
                     );

--- a/src/features/alert/AlertCenter/AlertCenterDetailFeed.tsx
+++ b/src/features/alert/AlertCenter/AlertCenterDetailFeed.tsx
@@ -1,20 +1,20 @@
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import type { AlertItemRow, AlertTag } from './alertCenter.types';
-import { getNotificationDetailMock } from './alertCenter.mock';
 import { isTodayNotifiedDate, notificationDetailToAlertGroups } from './alertCenterDetailAdapter';
 import AlertStockAvatar from './AlertStockAvatar';
+import { useNotificationDetail } from '../hooks/useNotificationDetail';
 
 function TagChip({ tag }: { tag: AlertTag }) {
   if (tag.variant === 'outline') {
     return (
       <span className="rounded-md border border-[#C7DBFF] bg-[#F4F6FB] px-2 py-0.5 text-[10px] text-[#014D9D]">
-        {tag.label}
+        #{tag.label}
       </span>
     );
   }
   return (
     <span className="rounded-md border border-[#C7DBFF] bg-[#F4F6FB] px-2 py-0.5 text-[10px] font-medium text-[#014D9D]">
-      {tag.label}
+      #{tag.label}
     </span>
   );
 }
@@ -29,7 +29,7 @@ function EventContent({ item }: { item: AlertItemRow }) {
       {item.tags && item.tags.length > 0 && (
         <div className="mt-2 flex flex-wrap gap-1.5">
           {item.tags.map((tag) => (
-            <TagChip key={`${item.headline}-${tag.label}`} tag={tag} />
+            <TagChip key={`${item.headline}-$#{tag.label}`} tag={tag} />
           ))}
         </div>
       )}
@@ -40,9 +40,7 @@ function EventContent({ item }: { item: AlertItemRow }) {
 const PX = 18;
 
 export interface AlertCenterDetailFeedProps {
-  /** GET /api/notifications/{notificationId} 조회 키 (목업은 `getNotificationDetailMock`) */
   notificationId: number | null;
-  /** 세부 탭에서 해당 알림의 모든 그룹을 읽음 처리했을 때 (전체 탭 행 강조 등) */
   onNotificationDetailFullyRead?: (notificationId: number) => void;
 }
 
@@ -51,20 +49,18 @@ export default function AlertCenterDetailFeed({
   onNotificationDetailFullyRead,
 }: AlertCenterDetailFeedProps) {
   const [readStateByGroup, setReadStateByGroup] = useState<Record<string, boolean>>({});
+  const [collapsedByGroup, setCollapsedByGroup] = useState<Record<string, boolean>>({});
+  const { data: allDetails } = useNotificationDetail({ days: 7 });
+
+  const detail = notificationId != null
+    ? allDetails.find((n) => n.notificationId === notificationId) ?? null
+    : null;
 
   const sections = useMemo(() => {
-    if (notificationId == null) return [];
-    const detail = getNotificationDetailMock(notificationId);
     if (!detail) return [];
     const groups = notificationDetailToAlertGroups(detail);
-    return [
-      {
-        date: detail.notifiedDate,
-        isToday: isTodayNotifiedDate(detail.notifiedDate),
-        groups,
-      },
-    ];
-  }, [notificationId]);
+    return [{ date: detail.date, isToday: isTodayNotifiedDate(detail.date), groups }];
+  }, [detail]);
 
   const allGroupKeys = useMemo(() => {
     const keys: string[] = [];
@@ -141,10 +137,19 @@ export default function AlertCenterDetailFeed({
                   {(() => {
                     const groupKey = getGroupKey(date, group.code);
                     const isRead = !!readStateByGroup[groupKey];
+                    const isCollapsed = collapsedByGroup[groupKey] !== false; // 기본 접힘
                     return (
                       <>
                         <div className="relative z-10 border-b border-[#f3f4f6] last:border-b-0">
-                          <div className="-mx-[18px] flex w-[calc(100%+36px)] items-center gap-3 px-[18px] py-3 transition-colors hover:bg-[#F0F2F8]">
+                          <div
+                            className="-mx-[18px] flex w-[calc(100%+36px)] cursor-pointer items-center gap-3 px-[18px] py-3 transition-colors hover:bg-[#F0F2F8]"
+                            onClick={() =>
+                              setCollapsedByGroup((prev) => ({
+                                ...prev,
+                                [groupKey]: !isCollapsed,
+                              }))
+                            }
+                          >
                             <div className="relative shrink-0">
                               <AlertStockAvatar color={group.color} ini={group.ini} />
                               {!isRead && (
@@ -166,6 +171,14 @@ export default function AlertCenterDetailFeed({
                                 <div className="mt-0 text-[11px] leading-4 text-[#6b7280]">{group.summaryLine}</div>
                               )}
                             </div>
+
+                            <span
+                              className={`shrink-0 text-[10px] text-[#9ca3af] transition-transform duration-200 ${
+                                isCollapsed ? '' : 'rotate-180'
+                              }`}
+                            >
+                              ▼
+                            </span>
                           </div>
 
                           <div
@@ -175,53 +188,55 @@ export default function AlertCenterDetailFeed({
                           />
                         </div>
 
-                        <div
-                          className={`relative z-10 border-b border-[#f3f4f6] last:border-b-0 ${
-                            isRead ? 'bg-[#F0F2F8]' : 'bg-white'
-                          }`}
-                          style={{ marginLeft: -PX, marginRight: -PX, paddingLeft: PX, paddingRight: PX }}
-                        >
-                          <div className="relative flex flex-col">
-                            <div className="absolute top-0 bottom-0 left-[-2px] z-30 w-[2px] bg-[#D8E2F8]" aria-hidden />
-                            {group.items.map((item, itemIdx) => (
-                              <div
-                                key={`${group.code}-${itemIdx}`}
-                                className="relative -mx-[18px] flex w-[calc(100%+36px)] items-stretch gap-2.5 px-[18px] py-2 transition-colors hover:bg-[#F0F2F8]"
-                              >
-                                <div className="flex w-4 shrink-0 flex-col items-center">
-                                  <span
-                                    className="relative z-30 -ml-[17px] mt-1 h-1.5 w-1.5 shrink-0 rounded-full ring-3 ring-white"
-                                    style={{ backgroundColor: item.dotColor }}
-                                    aria-hidden
-                                  />
-                                </div>
-                                <div className="min-w-0 flex-1">
-                                  <EventContent item={item} />
-                                </div>
+                        {!isCollapsed && (
+                          <>
+                            <div
+                              className={`relative z-10 border-b border-[#f3f4f6] last:border-b-0 ${
+                                isRead ? 'bg-[#F0F2F8]' : 'bg-white'
+                              }`}
+                              style={{ marginLeft: -PX, marginRight: -PX, paddingLeft: PX, paddingRight: PX }}
+                            >
+                              <div className="relative flex flex-col">
+                                <div className="absolute top-0 bottom-0 left-[-2px] z-30 w-[2px] bg-[#D8E2F8]" aria-hidden />
+                                {group.items.map((item, itemIdx) => (
+                                  <div
+                                    key={`${group.code}-${itemIdx}`}
+                                    className="relative -mx-[18px] flex w-[calc(100%+36px)] items-stretch gap-2.5 px-[18px] py-2 transition-colors hover:bg-[#F0F2F8]"
+                                  >
+                                    <div className="flex w-4 shrink-0 flex-col items-center">
+                                      <span
+                                        className="relative z-30 -ml-[17px] mt-1 h-1.5 w-1.5 shrink-0 rounded-full ring-3 ring-white"
+                                        style={{ backgroundColor: item.dotColor }}
+                                        aria-hidden
+                                      />
+                                    </div>
+                                    <div className="min-w-0 flex-1">
+                                      <EventContent item={item} />
+                                    </div>
+                                  </div>
+                                ))}
                               </div>
-                            ))}
-                          </div>
-                        </div>
-                        <div
-                          className="relative z-10 flex items-center justify-between gap-3 border-y border-[#f3f4f6] bg-[#F0F2F8] py-2.5"
-                          style={{ marginLeft: -PX, marginRight: -PX, paddingLeft: PX, paddingRight: PX }}
-                        >
-                          <span className="text-[12px] font-medium text-[#6b7280]">총 {group.items.length}건</span>
-                          <button
-                            type="button"
-                            onClick={() =>
-                              setReadStateByGroup((prev) => ({
-                                ...prev,
-                                [groupKey]: true,
-                              }))
-                            }
-                            className={`shrink-0 border-0 bg-transparent p-0 text-[11.5px] font-bold ${
-                              isRead ? 'text-[#9ca3af]' : 'text-[#014d9d]'
-                            }`}
-                          >
-                            {isRead ? '읽음' : '읽음 처리'}
-                          </button>
-                        </div>
+                            </div>
+                            <div
+                              className="relative z-10 flex items-center justify-between gap-3 border-y border-[#f3f4f6] bg-[#F0F2F8] py-2.5"
+                              style={{ marginLeft: -PX, marginRight: -PX, paddingLeft: PX, paddingRight: PX }}
+                            >
+                              <span className="text-[12px] font-medium text-[#6b7280]">총 {group.items.length}건</span>
+                              <button
+                                type="button"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  setReadStateByGroup((prev) => ({ ...prev, [groupKey]: true }));
+                                }}
+                                className={`shrink-0 border-0 bg-transparent p-0 text-[11.5px] font-bold ${
+                                  isRead ? 'text-[#9ca3af]' : 'text-[#014d9d]'
+                                }`}
+                              >
+                                {isRead ? '읽음' : '읽음 처리'}
+                              </button>
+                            </div>
+                          </>
+                        )}
                       </>
                     );
                   })()}

--- a/src/features/alert/AlertCenter/AlertStockAvatar.tsx
+++ b/src/features/alert/AlertCenter/AlertStockAvatar.tsx
@@ -1,4 +1,20 @@
-export default function AlertStockAvatar({ color, ini }: { color: string; ini: string }) {
+interface AlertStockAvatarProps {
+  color: string;
+  ini: string;
+  logoUrl?: string | null;
+}
+
+export default function AlertStockAvatar({ color, ini, logoUrl }: AlertStockAvatarProps) {
+  if (logoUrl) {
+    return (
+      <img
+        src={logoUrl}
+        alt=""
+        className="h-7 w-7 shrink-0 rounded-[7px] object-cover"
+      />
+    );
+  }
+
   return (
     <div
       className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[7px] text-[9px] font-black leading-[13.5px] text-white"

--- a/src/features/alert/AlertCenter/alertCenter.types.ts
+++ b/src/features/alert/AlertCenter/alertCenter.types.ts
@@ -25,5 +25,6 @@ export type AlertGroup = {
   summaryLine?: string;
   date: string;
   isToday: boolean;
+  logoUrl?: string | null;
 };
 

--- a/src/features/alert/AlertCenter/alertCenterDetailAdapter.ts
+++ b/src/features/alert/AlertCenter/alertCenterDetailAdapter.ts
@@ -1,5 +1,5 @@
 import type { AlertGroup, AlertItemRow, AlertTag } from './alertCenter.types';
-import type { NotificationDetailResponse, NotificationStockGroup } from './notificationApi.types';
+import type { NotificationDetailItem, StockNewsGroup } from '@/shared/api/notifications/types';
 
 const STOCK_COLORS = ['#1428a0', '#EA1917', '#0f766e', '#7c3aed'] as const;
 
@@ -12,65 +12,40 @@ function tagsFromStrings(tags: string[]): AlertTag[] {
   return tags.map((label) => ({ label, variant: 'solid' as const, tone: 'neutral' as const }));
 }
 
-function stockGroupToAlertGroup(sg: NotificationStockGroup, index: number, date: string, isToday: boolean): AlertGroup {
+function stockGroupToAlertGroup(sg: StockNewsGroup, index: number, date: string, isToday: boolean): AlertGroup {
   const color = STOCK_COLORS[index % STOCK_COLORS.length];
-  const items: AlertItemRow[] = [];
-
-  for (const n of sg.newsItems) {
-    items.push({
-      dotColor: '#3b82f6',
-      headline: n.title,
-      chg: null,
-      desc: n.source,
-      tags: tagsFromStrings(n.tags),
-    });
-  }
-
-  for (const e of sg.eventAlerts) {
-    const sign = e.changeRate >= 0 ? '+' : '';
-    items.push({
-      dotColor: e.eventType === 'SURGE' ? '#ef4444' : '#2563eb',
-      headline: `${e.eventType === 'SURGE' ? '급등' : '급락'} ${sign}${e.changeRate}%`,
-      chg: `${sign}${e.changeRate}%`,
-      desc: e.summary,
-      tags: [{ label: '기업·실적', variant: 'solid', tone: 'neutral' }],
-    });
-  }
-
-  if (sg.reviewAlert) {
-    items.push({
-      dotColor: '#f97316',
-      headline: '📌 스크랩 이벤트 1개월 복기',
-      chg: null,
-      desc: sg.reviewAlert.message,
-      tags: [{ label: '#스크랩 복기', variant: 'solid', tone: 'neutral' }],
-    });
-  }
+  const items: AlertItemRow[] = sg.newsList.map((n) => ({
+    dotColor: '#3b82f6',
+    headline: n.title,
+    chg: null,
+    desc: n.source,
+    tags: tagsFromStrings(n.tags),
+  }));
 
   return {
-    ini: initials(sg.name),
+    ini: initials(sg.stockName),
     color,
-    name: sg.name,
+    name: sg.stockName,
     code: sg.ticker,
     badgeColor: '#dc2626',
     relativeTime: '',
-    summaryLine: sg.eventSummary,
+    summaryLine: `뉴스 ${sg.newsCount}건`,
     items,
     date,
     isToday,
   };
 }
 
-export function isTodayNotifiedDate(isoDate: string): boolean {
-  const [y, m, d] = isoDate.split('-').map(Number);
+// date format: "yyyy.MM.dd"
+export function isTodayNotifiedDate(date: string): boolean {
+  const [y, m, d] = date.split('.').map(Number);
   if (!y || !m || !d) return false;
   const t = new Date();
   return t.getFullYear() === y && t.getMonth() + 1 === m && t.getDate() === d;
 }
 
-/** GET /notifications/{id} 응답 → 세부 탭 그룹 (동일 날짜 섹션 1개) */
-export function notificationDetailToAlertGroups(detail: NotificationDetailResponse): AlertGroup[] {
-  const { notifiedDate, stockGroups } = detail;
-  const isToday = isTodayNotifiedDate(notifiedDate);
-  return stockGroups.map((sg, i) => stockGroupToAlertGroup(sg, i, notifiedDate, isToday));
+export function notificationDetailToAlertGroups(detail: NotificationDetailItem): AlertGroup[] {
+  const { date, stocks } = detail;
+  const isToday = isTodayNotifiedDate(date);
+  return stocks.map((sg, i) => stockGroupToAlertGroup(sg, i, date, isToday));
 }

--- a/src/features/alert/AlertCenter/alertCenterDetailAdapter.ts
+++ b/src/features/alert/AlertCenter/alertCenterDetailAdapter.ts
@@ -33,6 +33,7 @@ function stockGroupToAlertGroup(sg: StockNewsGroup, index: number, date: string,
     items,
     date,
     isToday,
+    logoUrl: sg.logoUrl ?? null,
   };
 }
 

--- a/src/features/alert/components/NotificationBadge.tsx
+++ b/src/features/alert/components/NotificationBadge.tsx
@@ -1,0 +1,29 @@
+import { useNotificationBadge } from '../hooks/useNotificationBadge';
+
+interface NotificationBadgeProps {
+  className?: string;
+}
+
+export const NotificationBadge = ({ className }: NotificationBadgeProps) => {
+  const { count, isLoading, isError } = useNotificationBadge();
+
+  if (isLoading || isError || count === 0) return null;
+
+  const displayCount = count >= 100 ? '99+' : String(count);
+
+  return (
+    <span
+      className={`
+        absolute -top-1 -right-1
+        min-w-[18px] h-[18px] px-1
+        flex items-center justify-center
+        rounded-full
+        bg-[#EF4444] text-white
+        text-[10px] font-bold leading-none
+        ${className ?? ''}
+      `}
+    >
+      {displayCount}
+    </span>
+  );
+};

--- a/src/features/alert/hooks/useNotificationBadge.ts
+++ b/src/features/alert/hooks/useNotificationBadge.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { getUnreadCount } from '@/shared/api/notifications/notificationApi';
+import { notificationKeys } from '@/shared/queryKeys';
+
+export const useNotificationBadge = () => {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: notificationKeys.unreadCount(),
+    queryFn: getUnreadCount,
+    staleTime: 30 * 1000,
+    refetchInterval: 60 * 1000,
+  });
+
+  return {
+    count: data?.count ?? 0,
+    isLoading,
+    isError,
+  };
+};

--- a/src/features/alert/hooks/useNotificationDetail.ts
+++ b/src/features/alert/hooks/useNotificationDetail.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query';
+import { getNotificationDetail } from '@/shared/api/notifications/notificationApi';
+import { notificationKeys } from '@/shared/queryKeys';
+
+interface UseNotificationDetailParams {
+  days?: number;
+  stockId?: number;
+  read?: boolean;
+  enabled?: boolean;
+}
+
+export const useNotificationDetail = ({
+  days,
+  stockId,
+  read,
+  enabled = true,
+}: UseNotificationDetailParams = {}) => {
+  const params = { days, stockId, read };
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: notificationKeys.detail(params),
+    queryFn: () => getNotificationDetail(params),
+    staleTime: 30 * 1000,
+    enabled,
+  });
+
+  return {
+    data: data ?? [],
+    isLoading,
+    isError,
+  };
+};

--- a/src/features/alert/hooks/useNotificationMutations.ts
+++ b/src/features/alert/hooks/useNotificationMutations.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  markNotificationRead,
+  markAllNotificationsRead,
+} from '@/shared/api/notifications/notificationApi';
+import { notificationKeys } from '@/shared/queryKeys';
+
+export const useMarkNotificationRead = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (notificationId: number) => markNotificationRead(notificationId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: notificationKeys.all });
+    },
+  });
+};
+
+export const useMarkAllNotificationsRead = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: markAllNotificationsRead,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: notificationKeys.all });
+    },
+  });
+};

--- a/src/features/alert/hooks/useNotificationSummary.ts
+++ b/src/features/alert/hooks/useNotificationSummary.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import { getNotificationSummary } from '@/shared/api/notifications/notificationApi';
+import { notificationKeys } from '@/shared/queryKeys';
+
+export const useNotificationSummary = (days?: number) => {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: notificationKeys.summary(days),
+    queryFn: () => getNotificationSummary(days),
+    staleTime: 30 * 1000,
+  });
+
+  return {
+    data: data ?? [],
+    isLoading,
+    isError,
+  };
+};

--- a/src/shared/api/notifications/notificationApi.ts
+++ b/src/shared/api/notifications/notificationApi.ts
@@ -1,0 +1,54 @@
+import apiClient from '@/shared/api/axios';
+import type {
+  ApiResponse,
+  NotificationSummaryItem,
+  NotificationDetailItem,
+  UnreadCountResult,
+} from './types';
+
+// 1. 알림 요약 목록 조회
+// GET /api/notifications/summary?days={days}
+export const getNotificationSummary = async (
+  days?: number
+): Promise<NotificationSummaryItem[]> => {
+  const { data } = await apiClient.get<ApiResponse<NotificationSummaryItem[]>>(
+    '/api/notifications/summary',
+    { params: days !== undefined ? { days } : undefined }
+  );
+  return data.result;
+};
+
+// 2. 알림 세부 목록 조회
+// GET /api/notifications?days={days}&stockId={stockId}&read={read}
+export const getNotificationDetail = async (params?: {
+  days?: number;
+  stockId?: number;
+  read?: boolean;
+}): Promise<NotificationDetailItem[]> => {
+  const { data } = await apiClient.get<ApiResponse<NotificationDetailItem[]>>(
+    '/api/notifications',
+    { params }
+  );
+  return data.result;
+};
+
+// 3. 미읽음 알림 수 조회
+// GET /api/notifications/unread-count
+export const getUnreadCount = async (): Promise<UnreadCountResult> => {
+  const { data } = await apiClient.get<ApiResponse<UnreadCountResult>>(
+    '/api/notifications/unread-count'
+  );
+  return data.result;
+};
+
+// 4. 개별 알림 읽음 처리
+// PATCH /api/notifications/{notificationId}/read
+export const markNotificationRead = async (notificationId: number): Promise<void> => {
+  await apiClient.patch(`/api/notifications/${notificationId}/read`);
+};
+
+// 5. 전체 알림 읽음 처리
+// PATCH /api/notifications/read-all
+export const markAllNotificationsRead = async (): Promise<void> => {
+  await apiClient.patch('/api/notifications/read-all');
+};

--- a/src/shared/api/notifications/types.ts
+++ b/src/shared/api/notifications/types.ts
@@ -1,139 +1,55 @@
 /**
- * Notification API — `08_notification.md` 명세와 동기화
- * Base: `/api/notifications`
+ * Notification API 타입 정의
+ * Base: /api/notifications
  */
 
-/** 공통 래핑 응답 (성공 시) */
-export interface ApiSuccessEnvelope<T> {
-  code: string;
-  message: string;
-  data: T;
+// 공통 응답 래퍼
+export interface ApiResponse<T> {
+  isSuccess: boolean;
+  responseCode: number;
+  responseMessage: string;
+  result: T;
 }
 
-// --- 1. unread-count ---
-
-export interface UnreadCountData {
-  unreadCount: number;
-}
-
-// --- 2. GET /notifications (전체 탭 목록) ---
-
-export type NotificationReadStatusFilter = 'READ' | 'UNREAD';
-
-export interface NotificationListParams {
-  stockId?: number;
-  tagName?: string;
-  startDate?: string;
-  endDate?: string;
-  readStatus?: NotificationReadStatusFilter;
-  page?: number;
-  size?: number;
-}
-
-export interface NotificationListStock {
-  stockId: number;
-  ticker: string;
-  name: string;
-  logoUrl: string;
-  newsCount: number;
-}
-
-export interface NotificationListItem {
-  notifiedDate: string;
-  daysAgo: number;
-  isRead: boolean;
+// 알림 요약 아이템 (GET /api/notifications/summary)
+export interface NotificationSummaryItem {
   notificationId: number;
-  stocks: NotificationListStock[];
+  date: string;         // "yyyy.MM.dd"
+  stockNames: string;   // "삼성전자, SK하이닉스" 또는 "삼성전자 외 N개"
+  relativeTime: string; // "오늘", "1일 전", "N일 전"
+  message: string;      // **bold** 마크다운 포함
+  isRead: boolean;
 }
 
-export interface NotificationListData {
-  page: number;
-  size: number;
-  totalCount: number;
-  items: NotificationListItem[];
-}
-
-// --- 3. GET /notifications/{id} (세부) ---
-
-export interface NotificationNewsItem {
+// 뉴스 아이템
+export interface NewsItem {
   newsId: number;
   title: string;
+  summary: string;
+  publishedAt: string; // "yyyy.MM.dd HH:mm"
   source: string;
   url: string;
-  publishedAt: string;
   tags: string[];
 }
 
-export type EventAlertType = 'SURGE' | 'DROP' | string;
-
-export interface NotificationEventAlert {
-  eventId: number;
-  eventType: EventAlertType;
-  changeRate: number;
-  summary: string;
-}
-
-export interface NotificationReviewAlert {
-  eventId: number;
-  changeRate: number;
-  message: string;
-}
-
-export interface NotificationStockGroup {
+// 종목별 뉴스 그룹
+export interface StockNewsGroup {
   stockId: number;
+  stockName: string;
   ticker: string;
-  name: string;
-  logoUrl: string;
-  eventSummary: string;
-  newsItems: NotificationNewsItem[];
-  eventAlerts: NotificationEventAlert[];
-  reviewAlert: NotificationReviewAlert | null;
+  newsCount: number;
+  newsList: NewsItem[];
 }
 
-export interface NotificationDetailData {
-  notificationId: number;
-  notifiedDate: string;
-  stockGroups: NotificationStockGroup[];
-}
-
-// --- 4. PATCH /notifications/read ---
-
-export interface NotificationReadRequest {
-  notificationIds: number[];
-}
-
-export interface NotificationReadResult {
-  updatedCount: number;
-}
-
-// --- 5. GET /notifications/history ---
-
-export interface NotificationHistoryParams {
-  stockId?: number;
-  page?: number;
-  size?: number;
-}
-
-export type NotificationHistoryType = 'NEWS' | 'EVENT' | 'REVIEW' | 'SYSTEM';
-
-export interface NotificationHistoryItem {
-  notificationId: number;
-  type: NotificationHistoryType;
-  title: string;
-  description: string;
-  isRead: boolean;
-  createdAt: string;
-}
-
-export interface NotificationHistoryGroup {
+// 알림 세부 아이템 (GET /api/notifications)
+export interface NotificationDetailItem {
   date: string;
-  label: string;
-  items: NotificationHistoryItem[];
+  notificationId: number;
+  isRead: boolean;
+  stocks: StockNewsGroup[];
 }
 
-export interface NotificationHistoryData {
-  page: number;
-  size: number;
-  totalCount: number;
-  groups: NotificationHistoryGroup[];
+// 미읽음 수 (GET /api/notifications/unread-count)
+export interface UnreadCountResult {
+  count: number;
 }

--- a/src/shared/api/notifications/types.ts
+++ b/src/shared/api/notifications/types.ts
@@ -38,6 +38,7 @@ export interface StockNewsGroup {
   stockName: string;
   ticker: string;
   newsCount: number;
+  logoUrl?: string | null;
   newsList: NewsItem[];
 }
 

--- a/src/shared/components/layout/Header.tsx
+++ b/src/shared/components/layout/Header.tsx
@@ -12,7 +12,8 @@ import LoginModal from "@/features/auth/components/LoginModal";
 import SignupModal from "@/features/auth/components/SignupModal";
 import MyPagePanel from "@/pages/MyPage/components/MyPagePanel";
 import AlertCenter from "@/features/alert/AlertCenter/AlertCenter";
-import { alertCenterListHasUnread } from "@/features/alert/AlertCenter/alertCenter.mock";
+import { NotificationBadge } from "@/features/alert/components/NotificationBadge";
+import { useNotificationBadge } from "@/features/alert/hooks/useNotificationBadge";
 import { logoutFromServer } from "@/features/auth/api/authApi";
 
 
@@ -30,12 +31,11 @@ export default function Header({ onMyPageOpen, disableMyPagePanel = false }: Hea
   const [alertOpen, setAlertOpen] = useState(false);
   const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
   const [alertAnchor, setAlertAnchor] = useState<"mobile" | "desktop" | null>(null);
-  const [allListMarkedRead, setAllListMarkedRead] = useState(false);
-  const [detailFullyReadIds, setDetailFullyReadIds] = useState<Set<number>>(() => new Set());
   const mobileAlertContainerRef = useRef<HTMLDivElement | null>(null);
   const desktopAlertContainerRef = useRef<HTMLDivElement | null>(null);
 
-  const hasUnread = alertCenterListHasUnread(allListMarkedRead, detailFullyReadIds);
+  const { count: unreadCount } = useNotificationBadge();
+  const hasUnread = unreadCount > 0;
 
   const renderAlertButton = (
     anchor: "mobile" | "desktop",
@@ -49,20 +49,15 @@ export default function Header({ onMyPageOpen, disableMyPagePanel = false }: Hea
           setAlertAnchor(anchor);
           setAlertOpen((prev) => (alertAnchor === anchor ? !prev : true));
         }}
-        className="flex items-center justify-center"
+        className="relative flex items-center justify-center"
       >
         <img src={hasUnread ? bellSrc : bellNotSrc} alt="알림" className="w-8.5 h-8.5" />
+        <NotificationBadge />
       </button>
       {alertOpen && alertAnchor === anchor && (
         <AlertCenter
           onClose={() => setAlertOpen(false)}
           containerRef={containerRef}
-          allListMarkedRead={allListMarkedRead}
-          onAllListMarkedRead={() => setAllListMarkedRead(true)}
-          detailFullyReadIds={detailFullyReadIds}
-          onNotificationDetailFullyRead={(notificationId) => {
-            setDetailFullyReadIds((prev) => new Set(prev).add(notificationId));
-          }}
         />
       )}
     </div>

--- a/src/shared/queryKeys.ts
+++ b/src/shared/queryKeys.ts
@@ -1,0 +1,9 @@
+export const notificationKeys = {
+  all: ['notifications'] as const,
+  summary: (days?: number) =>
+    [...notificationKeys.all, 'summary', { days }] as const,
+  detail: (params?: { days?: number; stockId?: number; read?: boolean }) =>
+    [...notificationKeys.all, 'detail', params] as const,
+  unreadCount: () =>
+    [...notificationKeys.all, 'unreadCount'] as const,
+};


### PR DESCRIPTION
## #️⃣ Issue Number
- Closes #77

## 📝 변경사항
알림센터가 Mock 데이터에 의존하던 구조를 실제 백엔드 API와 연동하도록 전면 교체합니다.
API 레이어(타입 정의 + axios 함수)와 TanStack Query hooks를 새로 구현하고,
GNB 뱃지 및 알림센터 컴포넌트에 연결합니다.

### 🎯 핵심 변경 사항 (Key Changes)

- [x] 알림 API 타입 정의 및 axios 함수 5개 구현 (`/api/notifications` 하위 엔드포인트)
- [x] TanStack Query hooks 구현 (`useNotificationBadge`, `useNotificationSummary`, `useNotificationDetail`, `useMarkNotificationRead`, `useMarkAllNotificationsRead`)
- [x] GNB 알림 아이콘에 미읽음 수 뱃지 실시간 표시 (1분 폴링)
- [x] 알림센터 "전체" 탭 Mock 제거 → `useNotificationSummary(7)` 연결, API `message` 필드 bold 마크다운 파싱 렌더링
- [x] 알림센터 "세부 알림" 탭 Mock 제거 → `useNotificationDetail({ days: 7 })` 연결, 종목별 뉴스 기본 접힘/펼치기
- [x] Header에서 Mock 기반 상태(`allListMarkedRead`, `detailFullyReadIds`) 제거

### 🔍 주안점 & 리뷰 포인트

- `notificationKeys.all` 단위로 invalidate하여 뱃지·요약·세부 쿼리를 한 번에 갱신하는 방식이 적절한지 확인 부탁드립니다.
- `useNotificationDetail`은 7일치 전체 목록을 fetch한 뒤 클라이언트에서 `notificationId`로 필터링합니다. 단일 ID 조회 엔드포인트가 추가될 경우 교체가 필요합니다.
- `AlertCenter` props에서 읽음 상태 관리를 Header → AlertCenter 내부로 이동했습니다. 상태 소유권 변경이 의도에 맞는지 봐주세요.

### 🖼️ 스크린샷 / 테스트 결과 (선택 사항)

(백엔드 연동 후 추가 예정)

---

## 🛠️ PR 유형
- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [x] 💄 UI/UX 디자인 변경
- [x] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## 🧪 영향 범위 및 테스트 (Impact & Tests)

### **영향을 받는 모듈/컴포넌트:**
`src/shared/api/notifications`, `src/shared/queryKeys.ts`, `src/features/alert/hooks`, `src/features/alert/components/NotificationBadge`, `src/features/alert/AlertCenter`, `src/shared/components/layout/Header`

### **테스트 방법:**
- [ ] 단위 테스트 (JUnit/Jest)
- [ ] 통합 테스트
- [x] 수동 API 테스트 (Postman/Swagger)

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 불필요한 로그나 주석을 제거했습니다.
- [x] 관련 이슈를 연결했습니다.