### PR TITLE
[Feat] daily news api 연동 및 차트 핀 추가

### DIFF
--- a/src/app/router/AppRouter.tsx
+++ b/src/app/router/AppRouter.tsx
@@ -9,6 +9,7 @@ import MobileLayout from '@/shared/components/layout/MobileLayout';
 import { StockDetailMain } from '@/pages/Chart/components/StockDetailMain';
 import InterestStockAside from '@/pages/InterestStock/components/InterestStockAside';
 import StockDetailAside from '@/pages/StockDetail/components/StockDetailaside';
+import TodayLearningPage from '@/pages/TodayLearning';
 import LoginPage from '@/pages/Login';
 import SignupPage from '@/pages/Signup';
 
@@ -54,6 +55,16 @@ const router = createBrowserRouter([
         left={<StockDetailMain />}
         right={<NewsPage />}
         mobile={<StockDetailMain mobileMode="news" />}
+      />
+    ),
+  },
+  {
+    path: '/chart/:stockCode/today-learning',
+    element: (
+      <SplitRoute
+        left={<StockDetailMain />}
+        right={<TodayLearningPage />}
+        mobile={<StockDetailMain key="stock-detail" mobileMode="stock-detail" />}
       />
     ),
   },

--- a/src/features/news/api/learningApi.ts
+++ b/src/features/news/api/learningApi.ts
@@ -1,0 +1,49 @@
+import type { LearningPinResult, TodayLearningResult } from '@/features/news/types/news.types';
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL?.trim() || 'http://localhost:8080';
+
+/**
+ * 차트 핀 표시용 — 인증 불필요
+ * GET /api/stocks/{stockId}/learning-pin
+ * - 200: LearningPinResult 반환
+ * - 204: null 반환 (해당 종목 뉴스 없음)
+ */
+export async function fetchLearningPin(stockId: number): Promise<LearningPinResult | null> {
+  const res = await fetch(`${BASE_URL}/api/stocks/${stockId}/learning-pin`, {
+    credentials: 'include',
+  });
+
+  if (res.status === 204) {
+    return null;
+  }
+
+  if (!res.ok) {
+    throw new Error(`fetchLearningPin failed: ${res.status}`);
+  }
+
+  const json = await res.json();
+  return json.result as LearningPinResult;
+}
+
+/**
+ * 핀 클릭 시 사이드바용 — 선택적 인증 (쿠키 기반)
+ * GET /api/stocks/{stockId}/today-learning
+ * - 200: TodayLearningResult 반환
+ * - 204: null 반환 (해당 종목 뉴스 없음)
+ */
+export async function fetchTodayLearning(stockId: number): Promise<TodayLearningResult | null> {
+  const res = await fetch(`${BASE_URL}/api/stocks/${stockId}/today-learning`, {
+    credentials: 'include',
+  });
+
+  if (res.status === 204) {
+    return null;
+  }
+
+  if (!res.ok) {
+    throw new Error(`fetchTodayLearning failed: ${res.status}`);
+  }
+
+  const json = await res.json();
+  return json.result as TodayLearningResult;
+}

--- a/src/features/news/components/TodayLearningSidebar.tsx
+++ b/src/features/news/components/TodayLearningSidebar.tsx
@@ -1,0 +1,226 @@
+import { useTodayLearning } from '@/features/news/hooks/useTodayLearning';
+import type { PredictionInfo } from '@/features/news/types/news.types';
+
+interface TodayLearningSidebarProps {
+  stockId: number | undefined;
+  isOpen: boolean;
+  onClose: () => void;
+  isLoggedIn: boolean;
+  onLoginRequired: () => void;
+}
+
+// ─── 아이콘 ─────────────────────────────────────────────────────────────────
+
+function UpIcon() {
+  return (
+    <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="22 7 13.5 15.5 8.5 10.5 2 17" />
+      <polyline points="16 7 22 7 22 13" />
+    </svg>
+  );
+}
+
+function SidewaysIcon() {
+  return (
+    <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <line x1="5" y1="12" x2="19" y2="12" />
+      <polyline points="13 6 19 12 13 18" />
+    </svg>
+  );
+}
+
+function DownIcon() {
+  return (
+    <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="22 17 13.5 8.5 8.5 13.5 2 7" />
+      <polyline points="16 17 22 17 22 11" />
+    </svg>
+  );
+}
+
+// ─── 예측 섹션 ──────────────────────────────────────────────────────────────
+
+const DIRECTION_OPTIONS = [
+  { value: 'UP',       label: '상승', Icon: UpIcon,       activeColor: '#e03131', activeBg: '#FFF0F0' },
+  { value: 'SIDEWAYS', label: '횡보', Icon: SidewaysIcon, activeColor: '#6b7280', activeBg: '#f3f4f6' },
+  { value: 'DOWN',     label: '하락', Icon: DownIcon,     activeColor: '#1971c2', activeBg: '#EFF6FF' },
+] as const;
+
+interface PredictionSectionProps {
+  isLoggedIn: boolean;
+  prediction: PredictionInfo | undefined;
+  onLoginRequired: () => void;
+}
+
+function PredictionSection({ isLoggedIn, prediction, onLoginRequired }: PredictionSectionProps) {
+  return (
+    <div className="rounded-[10px] p-4 mb-4" style={{ background: '#fff', border: '1px solid #e5e7eb' }}>
+      <p className="text-[13px] font-semibold text-[#374151] mb-3">오를까? 내릴까?</p>
+      <div className="grid grid-cols-3 gap-2">
+        {DIRECTION_OPTIONS.map(({ value, label, Icon, activeColor, activeBg }) => {
+          // 예측 완료: 해당 방향 활성화, 나머지 비활성
+          const isDone = isLoggedIn && prediction !== undefined;
+          const isActive = isDone && prediction.direction === value;
+          const isDisabled = isDone && prediction.direction !== value;
+
+          return (
+            <button
+              key={value}
+              type="button"
+              disabled={isDisabled}
+              onClick={!isLoggedIn ? onLoginRequired : undefined}
+              className="flex flex-col items-center gap-1.5 py-3 rounded-[10px] transition-all active:opacity-70 disabled:opacity-40"
+              style={
+                isActive
+                  ? { color: activeColor, background: activeBg, border: `1.5px solid ${activeColor}` }
+                  : { color: '#9ca3af', background: '#f9fafb', border: '1.5px solid #e5e7eb' }
+              }
+            >
+              <Icon />
+              <span className="text-[13px] font-semibold">{label}</span>
+            </button>
+          );
+        })}
+      </div>
+      {prediction?.reason && (
+        <p className="mt-3 text-[12px] text-[#6b7280] leading-[1.6] bg-[#f9fafb] rounded-lg px-3 py-2">
+          {prediction.reason}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ─── 메인 컴포넌트 ───────────────────────────────────────────────────────────
+
+export default function TodayLearningSidebar({
+  stockId,
+  isOpen,
+  onClose,
+  isLoggedIn,
+  onLoginRequired,
+}: TodayLearningSidebarProps) {
+  const { data, isLoading, isError } = useTodayLearning(stockId, isOpen);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="flex flex-col h-full bg-[#f4f6fb]">
+      {/* 헤더 */}
+      <div className="shrink-0 bg-white">
+        <div className="relative flex h-[48px] items-center justify-center px-4">
+          <span className="text-[13px] font-semibold text-[#014D9D]">오늘의 학습</span>
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute right-4 flex items-center justify-center w-8 h-8 rounded-full hover:bg-[#f2f4f7] transition-colors"
+            aria-label="닫기"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#6b7280" strokeWidth="2" strokeLinecap="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+        <div className="h-[2px] w-full bg-[#014D9D]" />
+      </div>
+
+      {/* 컨텐츠 */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-4" style={{ scrollbarGutter: 'stable' }}>
+        {isLoading && (
+          <div className="flex items-center justify-center h-40">
+            <div className="w-6 h-6 border-2 border-[#014D9D] border-t-transparent rounded-full animate-spin" />
+          </div>
+        )}
+
+        {isError && (
+          <div className="flex items-center justify-center h-40 text-sm text-[#e03131]">
+            데이터를 불러오지 못했습니다.
+          </div>
+        )}
+
+        {!isLoading && !isError && data === null && (
+          <div className="flex items-center justify-center h-40 text-sm text-[#9ca3af]">
+            오늘의 뉴스가 없습니다.
+          </div>
+        )}
+
+        {!isLoading && !isError && data !== null && data !== undefined && (
+          <>
+            {/* 섹션 A — 가격 요약 카드 */}
+            <div
+              className="mt-3 mb-2.5 rounded-[14px] p-4"
+              style={{ background: '#014D9D' }}
+            >
+              <p className="text-[11px] text-[#93c5fd] mb-1">{data.digestDate}</p>
+              <div className="flex items-baseline gap-2 mb-1">
+                <span className="font-bold text-[20px] text-white">{data.stockName}</span>
+                {data.changeRate !== undefined && (
+                  <span
+                    className="font-bold text-[18px]"
+                    style={{
+                      color: data.changeRate.startsWith('+') ? '#fca5a5' : '#93c5fd',
+                    }}
+                  >
+                    {data.changeRate}
+                  </span>
+                )}
+              </div>
+              {data.priceClose !== undefined && data.prevPriceClose !== undefined && (
+                <p className="text-[13px] text-[#93c5fd]">
+                  {data.prevPriceClose.toLocaleString()}원 → {data.priceClose.toLocaleString()}원
+                </p>
+              )}
+            </div>
+
+            {/* 섹션 B — 예측 */}
+            <PredictionSection
+              isLoggedIn={isLoggedIn}
+              prediction={data.prediction}
+              onLoginRequired={onLoginRequired}
+            />
+
+            {/* 섹션 C — 관련 뉴스 */}
+            <div className="mb-4">
+              <p className="font-semibold text-sm text-[#374151] mb-2.5">관련 뉴스</p>
+              {data.newsList.length === 0 ? (
+                <p className="text-sm text-[#9ca3af]">관련 뉴스가 없습니다.</p>
+              ) : (
+                <div className="space-y-2.5">
+                  {data.newsList.map((item) => (
+                    <a
+                      key={item.newsId}
+                      href={item.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="block bg-white rounded-[10px] p-[12px_14px] hover:bg-[#f9fafb] transition-colors"
+                      style={{ border: '1px solid #e5e7eb' }}
+                    >
+                      <p className="font-bold text-sm text-[#101828] leading-[1.4] mb-1.5">{item.title}</p>
+                      <p className="text-[13px] text-[#6b7280] leading-[1.6] mb-2 line-clamp-2">{item.summary}</p>
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        <span className="text-[11px] text-[#9ca3af]">
+                          {item.source} · {item.publishedAt}
+                        </span>
+                        {item.tags.map((tag) => (
+                          <span
+                            key={tag}
+                            className="text-[11px] text-[#4b5563] bg-[#f3f4f6] px-2 py-0.5 rounded-full"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    </a>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="h-4" />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/news/hooks/useLearningPin.ts
+++ b/src/features/news/hooks/useLearningPin.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchLearningPin } from '@/features/news/api/learningApi';
+import { stockLearningKeys } from '@/shared/queryKeys';
+
+export function useLearningPin(stockId: number | undefined) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: stockLearningKeys.pin(stockId ?? 0),
+    queryFn: () => fetchLearningPin(stockId!),
+    enabled: stockId != null && stockId > 0,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return {
+    data: data ?? null,
+    isLoading,
+    isError,
+  };
+}

--- a/src/features/news/hooks/useTodayLearning.ts
+++ b/src/features/news/hooks/useTodayLearning.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchTodayLearning } from '@/features/news/api/learningApi';
+import { stockLearningKeys } from '@/shared/queryKeys';
+
+export function useTodayLearning(stockId: number | undefined, enabled: boolean) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: stockLearningKeys.today(stockId ?? 0),
+    queryFn: () => fetchTodayLearning(stockId!),
+    enabled: enabled && stockId != null && stockId > 0,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return {
+    data: data ?? null,
+    isLoading,
+    isError,
+  };
+}

--- a/src/features/news/types/news.types.ts
+++ b/src/features/news/types/news.types.ts
@@ -14,3 +14,36 @@ export interface TodayNews {
   aiSummary: string;
   relatedNews: RelatedNews[];
 }
+
+// 오늘의 학습 핀 (GET /api/stocks/{stockId}/learning-pin)
+export interface LearningPinResult {
+  digestDate: string; // "yyyy-MM-dd"
+  newsCount: number;
+}
+
+// 오늘의 학습 사이드바 (GET /api/stocks/{stockId}/today-learning)
+export interface PredictionInfo {
+  predictionId: number;
+  direction: 'UP' | 'DOWN' | 'SIDEWAYS';
+  reason: string;
+}
+
+export interface LearningNewsItem {
+  newsId: number;
+  title: string;
+  summary: string;
+  source: string;
+  publishedAt: string; // "yyyy.MM.dd"
+  url: string;
+  tags: string[];
+}
+
+export interface TodayLearningResult {
+  digestDate: string;          // "yyyy.MM.dd (요일)"
+  stockName: string;
+  changeRate?: string;         // "+1.23%" / "-2.76%", 키 자체가 없을 수 있음
+  priceClose?: number;
+  prevPriceClose?: number;
+  prediction?: PredictionInfo; // 키 자체가 없을 수 있음
+  newsList: LearningNewsItem[];
+}

--- a/src/pages/Chart/components/LearningPin.tsx
+++ b/src/pages/Chart/components/LearningPin.tsx
@@ -1,0 +1,38 @@
+import type { LearningPinResult } from '@/features/news/types/news.types';
+
+interface LearningPinProps {
+  data: LearningPinResult;
+  onClick: () => void;
+}
+
+/**
+ * 오늘의 학습 핀 — 모바일 차트 탭 칩 영역에서 사용
+ * 데스크톱 차트 핀은 LightweightCandleChart 내부 DOM 오버레이로 렌더링됨
+ */
+export function LearningPin({ data, onClick }: LearningPinProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="shrink-0 flex items-center gap-1.5 rounded-2xl border px-3 py-1.5 text-xs font-medium transition-colors active:opacity-70"
+      style={{
+        borderColor: '#93c5fd',
+        backgroundColor: '#eff6ff',
+        color: '#014D9D',
+      }}
+    >
+      {/* 마름모 아이콘 */}
+      <span
+        style={{
+          display: 'inline-block',
+          width: 8,
+          height: 8,
+          backgroundColor: '#014D9D',
+          transform: 'rotate(45deg)',
+          flexShrink: 0,
+        }}
+      />
+      오늘의 뉴스 · {data.newsCount}건
+    </button>
+  );
+}

--- a/src/pages/Chart/components/LightweightCandleChart.tsx
+++ b/src/pages/Chart/components/LightweightCandleChart.tsx
@@ -89,17 +89,25 @@ export function LightweightCandleChart({
   onHoverBar,
   /** 이벤트 핀 클릭 시 호출 — eventId 전달 */
   onEventClick,
+  /** 오늘의 학습 핀 데이터 — null이면 미표시 */
+  learningPin,
+  /** 오늘의 학습 핀 클릭 콜백 */
+  onLearningPinClick,
 }: {
   bars: OhlcBar[];
   visibleBars?: number;
   onHoverBar?: (bar: OhlcBar | null) => void;
   onEventClick?: (eventId: number) => void;
+  learningPin?: { digestDate: string; newsCount: number } | null;
+  onLearningPinClick?: () => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const hoverRef = useRef(onHoverBar);
   hoverRef.current = onHoverBar;
   const eventClickRef = useRef(onEventClick);
   eventClickRef.current = onEventClick;
+  const learningPinClickRef = useRef(onLearningPinClick);
+  learningPinClickRef.current = onLearningPinClick;
 
   useEffect(() => {
     const el = containerRef.current;
@@ -354,7 +362,90 @@ export function LightweightCandleChart({
     }
 
     renderHtmlPins();
-    chart.timeScale().subscribeVisibleLogicalRangeChange(renderHtmlPins);
+
+    // ─── 오늘의 학습 핀 (마름모) ────────────────────────────────────────────
+    const learningPinEl = document.createElement("div");
+    learningPinEl.style.cssText = [
+      "position:absolute",
+      "inset:0",
+      "pointer-events:none",
+      "overflow:visible",
+      "z-index:11",
+    ].join(";");
+    el.appendChild(learningPinEl);
+
+    function renderLearningPin() {
+      learningPinEl.innerHTML = "";
+      if (!el || !learningPin) return;
+
+      // digestDate("yyyy-MM-dd")를 bars에서 찾고, 없으면 마지막 봉 사용
+      const targetKey = learningPin.digestDate.slice(0, 10); // "yyyy-MM-dd"
+      const targetBar = clean.find((b) => barToTimeKey(b) === targetKey) ?? clean[clean.length - 1];
+      if (!targetBar) return;
+
+      const x = chart.timeScale().timeToCoordinate(barToTimeKey(targetBar) as Time);
+      if (x === null) return;
+
+      // 이벤트 핀과 동일하게 거래량 바 상단 좌표 기준
+      const y = volSeries.priceToCoordinate(targetBar.volume);
+      if (y === null) return;
+
+      const wrapper = document.createElement("div");
+      wrapper.style.cssText = [
+        "position:absolute",
+        `left:${x}px`,
+        `top:${y}px`,
+        "transform:translate(-50%, -100%)",
+        "display:flex",
+        "flex-direction:column",
+        "align-items:center",
+        "gap:3px",
+        "pointer-events:none",
+      ].join(";");
+
+      // 줄기
+      const stem = makeStem(false);
+      stem.style.background = "#EAB308";
+
+      // 핀 헤드 — 노란색
+      const head = ((): HTMLDivElement => {
+        const outer = document.createElement("div");
+        outer.style.cssText = [
+          "width:32px", "height:32px", "border-radius:50%",
+          "background:rgba(234,179,8,0.15)",
+          "display:flex", "align-items:center", "justify-content:center",
+          "cursor:pointer", "pointer-events:auto",
+        ].join(";");
+        const inner = document.createElement("div");
+        inner.style.cssText = [
+          "width:22px", "height:22px", "border-radius:50%",
+          "background:#EAB308",
+          "display:flex", "align-items:center", "justify-content:center",
+        ].join(";");
+        const icon = document.createElement("div");
+        icon.style.cssText = [
+          "width:8px", "height:8px",
+          "background:white",
+          "transform:rotate(45deg)",
+          "border-radius:1px",
+        ].join(";");
+        inner.appendChild(icon);
+        outer.appendChild(inner);
+        outer.addEventListener("click", (e) => { e.stopPropagation(); learningPinClickRef.current?.(); });
+        return outer;
+      })();
+      wrapper.appendChild(stem);
+      wrapper.appendChild(head);
+      learningPinEl.appendChild(wrapper);
+    }
+
+    renderLearningPin();
+
+    function renderAll() {
+      renderHtmlPins();
+      renderLearningPin();
+    }
+    chart.timeScale().subscribeVisibleLogicalRangeChange(renderAll);
 
     // ─── 크로스헤어 ──────────────────────────────────────────────────────────
     const crosshairHandler = (param: MouseEventParams) => {
@@ -408,16 +499,18 @@ export function LightweightCandleChart({
       const h = containerRef.current.clientHeight;
       chart.applyOptions({ width: w, height: h });
       renderHtmlPins();
+      renderLearningPin();
     });
     ro.observe(el);
 
     return () => {
-      chart.timeScale().unsubscribeVisibleLogicalRangeChange(renderHtmlPins);
+      chart.timeScale().unsubscribeVisibleLogicalRangeChange(renderAll);
       ro.disconnect();
       chart.remove();
       if (pinsEl.parentNode === el) el.removeChild(pinsEl);
+      if (learningPinEl.parentNode === el) el.removeChild(learningPinEl);
     };
-  }, [bars, visibleBars]);
+  }, [bars, visibleBars, learningPin]);
 
   if (!bars.length) {
     return (

--- a/src/pages/Chart/components/StockDetailMain.tsx
+++ b/src/pages/Chart/components/StockDetailMain.tsx
@@ -14,17 +14,18 @@ import {
   ohlcBarToSummary,
 } from "../hook";
 import { LightweightCandleChart } from "./LightweightCandleChart";
+import { LearningPin } from "./LearningPin";
 import { StockInfoBar } from "./StockInfoBar";
 import { PeriodTabs } from "./PeriodTabs";
 import { OhlcSummaryBar } from "./OhlcSummaryBar";
 import MarketIndexBar from "@/pages/widgets/MarketIndexBar/MarketIndexBar";
 import EventTab from "@/features/event/components/EventTab";
 import MemoTab from "@/features/event/components/MemoTab";
-import NewsTab from "@/features/news/components/NewsTab";
 import StockDetailAside from "@/pages/StockDetail/components/StockDetailaside";
 import { useEventDetail } from "@/features/event/hooks/useEventDetail";
 import { useMemos } from "@/features/event/hooks/useMemos";
-import type { TodayNews } from "@/features/news/types/news.types";
+import { useLearningPin } from "@/features/news/hooks/useLearningPin";
+import TodayLearningSidebar from "@/features/news/components/TodayLearningSidebar";
 
 
 /** 기간별로 한 화면에 보일 최대 봉 수(많을수록 조금 더 축소된 느낌) — 봉이 적으면 전체 표시 */
@@ -42,24 +43,6 @@ function visibleBarsForPeriod(tab: PeriodTab): number {
       return 120;
   }
 }
-const MOCK_NEWS: TodayNews = {
-  newsId: 1,
-  stockCode: "005930",
-  stockName: "삼성전자",
-  eventType: "PLUNGE",
-  occurredAt: "2026-03-17T09:00:00",
-  changeRate: 2.08,
-  priceBefore: 188000,
-  priceAfter: 184000,
-  aiSummary:
-    "이 구간에서는 엔비디아 GTC 컨퍼런스 이후 HBM3E 공급 기대감이 급격히 확대되었습니다. 삼성전자의 AI 칩 납품 재개 가능성이 보도되며 외국인 매수세가 집중된 것으로 확인됩니다.",
-  relatedNews: [
-    { newsId: 1, title: "외국인, 삼성전자 3일 연속 순매수 2조원 돌파", body: "외국인 투자자들이 삼성전자를 3거래일 연속 순매수하며 코스피 상승을 이끌었다.", source: "연합인포맥스", publishedAt: "2026-03-16T10:00:00", url: "#", tag: "외국인" },
-    { newsId: 2, title: "외국인, 삼성전자 3일 연속 순매수 2조원 돌파", body: "외국인 투자자들이 삼성전자를 3거래일 연속 순매수하며 코스피 상승을 이끌었다.", source: "연합인포맥스", publishedAt: "2026-03-16T11:00:00", url: "#", tag: "외국인" },
-    { newsId: 3, title: "외국인, 삼성전자 3일 연속 순매수 2조원 돌파", body: "외국인 투자자들이 삼성전자를 3거래일 연속 순매수하며 코스피 상승을 이끌었다.", source: "연합인포맥스", publishedAt: "2026-03-16T12:00:00", url: "#", tag: "외국인" },
-  ],
-};
-
 
 export interface StockDetailMainAllProps extends StockDetailMainProps {
   /** 티커 폴백 (라우트에 없을 때만) */
@@ -67,7 +50,7 @@ export interface StockDetailMainAllProps extends StockDetailMainProps {
   /** 직접 전달 시 검색 생략 — `GET /api/stocks/{stockId}/prices` */
   stockId?: number;
   useMock?: boolean;
-  mobileMode?: "stock-detail" | "event" | "news";
+  mobileMode?: "stock-detail" | "event" | "news" | "today-learning";
 }
 
 export function StockDetailMain({
@@ -79,7 +62,7 @@ export function StockDetailMain({
   mobileMode = "stock-detail",
 }: StockDetailMainAllProps) {
   const navigate = useNavigate();
-  const { refreshAuth } = useAuth();
+  const { refreshAuth, isLoggedIn } = useAuth();
   const [loginModalOpen, setLoginModalOpen] = useState(false);
   const { stockCode: stockCodeParam } = useParams<{ stockCode?: string }>();
   const [searchParams] = useSearchParams();
@@ -131,14 +114,15 @@ export function StockDetailMain({
 
   const { activePeriod, setActivePeriod } = useChartPeriod("일");
   const [mobileTab, setMobileTab] = useState<
-    "차트" | "기업 정보" | "이벤트" | "메모" | "오늘의 뉴스"
+    "차트" | "기업 정보" | "이벤트" | "메모" | "오늘의 뉴스" | "오늘의 학습"
   >(
     mobileMode === "event"
       ? "이벤트"
       : mobileMode === "news"
         ? "오늘의 뉴스"
-        : "차트"
+        : "기업 정보"
   );
+  const { data: learningPinData } = useLearningPin(chartStockId);
 
   const { event: mobileEvent, scrapping: mobileEventScrapping, toggleScrap } = useEventDetail(
     mobileMode === "event" ? mobileEventId : null
@@ -185,7 +169,9 @@ export function StockDetailMain({
       ? (["차트", "이벤트", "메모"] as const)
       : mobileMode === "news"
         ? (["차트", "오늘의 뉴스"] as const)
-        : (["차트", "기업 정보"] as const);
+        : learningPinData !== null
+          ? (["차트", "기업 정보", "오늘의 학습"] as const)
+          : (["차트", "기업 정보"] as const);
 
   const mobileEventChips = useMemo(() => {
     const chips: { label: string; positive: boolean; date: string }[] = [];
@@ -216,7 +202,7 @@ export function StockDetailMain({
           />
         </div>
 
-        <div className={`grid shrink-0 border-b border-[#eff1f8] ${mobileMode === "event" ? "grid-cols-3" : "grid-cols-2"}`}>
+        <div className={`grid shrink-0 border-b border-[#eff1f8] ${mobileTabs.length === 3 ? "grid-cols-3" : "grid-cols-2"}`}>
           {mobileTabs.map((tab) => (
             <button
               key={tab}
@@ -254,6 +240,12 @@ export function StockDetailMain({
                   이벤트 핀 데이터가 없습니다.
                 </div>
               )}
+              {learningPinData !== null && learningPinData !== undefined && (
+                <LearningPin
+                  data={learningPinData}
+                  onClick={() => setMobileTab("오늘의 학습")}
+                />
+              )}
             </div>
 
             <div className="shrink-0 bg-white px-4 py-2.5">
@@ -269,12 +261,24 @@ export function StockDetailMain({
                 visibleBars={chartVisibleBars}
                 onHoverBar={handleHoverBar}
                 onEventClick={handleEventClick}
+                learningPin={learningPinData}
+                onLearningPinClick={() => setMobileTab("오늘의 학습")}
               />
             </div>
           </>
         )}
 
-        {mobileTab === "오늘의 뉴스" && <NewsTab news={MOCK_NEWS} />}
+        {mobileTab === "오늘의 학습" && (
+          <div className="flex-1 min-h-0">
+            <TodayLearningSidebar
+              stockId={chartStockId}
+              isOpen
+              onClose={() => setMobileTab("차트")}
+              isLoggedIn={isLoggedIn}
+              onLoginRequired={() => setLoginModalOpen(true)}
+            />
+          </div>
+        )}
 
         {mobileTab === "기업 정보" && (
           <div className="flex-1 min-h-0 overflow-y-auto">
@@ -329,6 +333,8 @@ export function StockDetailMain({
             visibleBars={chartVisibleBars}
             onHoverBar={handleHoverBar}
             onEventClick={handleEventClick}
+            learningPin={learningPinData}
+            onLearningPinClick={() => navigate(`/chart/${stockCodeParam ?? ""}/today-learning`)}
           />
         </main>
 

--- a/src/pages/TodayLearning/index.tsx
+++ b/src/pages/TodayLearning/index.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import { useAuth } from '@/features/auth/context/AuthContext';
+import { fetchStockSearch } from '@/features/stock/api';
+import LoginModal from '@/features/auth/components/LoginModal';
+import TodayLearningSidebar from '@/features/news/components/TodayLearningSidebar';
+
+export default function TodayLearningPage() {
+  const { stockCode } = useParams<{ stockCode: string }>();
+  const navigate = useNavigate();
+  const { isLoggedIn, refreshAuth } = useAuth();
+  const [loginModalOpen, setLoginModalOpen] = useState(false);
+
+  const [stockId, setStockId] = useState<number | undefined>(undefined);
+
+  useEffect(() => {
+    if (!stockCode) return;
+    let cancelled = false;
+    fetchStockSearch(stockCode, 20)
+      .then((items) => {
+        if (cancelled) return;
+        const exact = items.find((i) => i.ticker === stockCode) ?? items[0];
+        setStockId(exact?.stockId);
+      })
+      .catch(() => {
+        if (!cancelled) setStockId(undefined);
+      });
+    return () => { cancelled = true; };
+  }, [stockCode]);
+
+  const handleClose = () => {
+    navigate(`/chart/${stockCode ?? ''}/stock-detail`);
+  };
+
+  return (
+    <>
+      <TodayLearningSidebar
+        stockId={stockId}
+        isOpen
+        onClose={handleClose}
+        isLoggedIn={isLoggedIn}
+        onLoginRequired={() => setLoginModalOpen(true)}
+      />
+      {loginModalOpen && (
+        <LoginModal
+          onClose={() => setLoginModalOpen(false)}
+          onSignup={() => {
+            setLoginModalOpen(false);
+            navigate('/signup');
+          }}
+          onLoginSuccess={async () => {
+            await refreshAuth();
+            setLoginModalOpen(false);
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/shared/queryKeys.ts
+++ b/src/shared/queryKeys.ts
@@ -1,3 +1,8 @@
+export const stockLearningKeys = {
+  pin: (stockId: number) => ['stock', stockId, 'learning-pin'] as const,
+  today: (stockId: number) => ['stock', stockId, 'today-learning'] as const,
+};
+
 export const notificationKeys = {
   all: ['notifications'] as const,
   summary: (days?: number) =>


### PR DESCRIPTION
## #️⃣ Issue Number
- Closes #93

## 📝 변경사항
종목 상세 차트에 "오늘의 학습 핀"을 표시하고, 클릭 시 관련 뉴스·예측 정보를 우측 패널(데스크톱) 또는 탭(모바일)으로 제공하는 기능을 추가했습니다.

### 🎯 핵심 변경 사항 (Key Changes)

- [ ] 오늘의 학습 API 레이어 추가 — `GET /api/stocks/{stockId}/learning-pin`, `GET /api/stocks/{stockId}/today-learning` 연동, 204 응답 시 body 파싱 없이 null 반환
- [ ] 차트 내 학습 핀 렌더링 — 기존 이벤트 핀과 동일한 DOM 오버레이 방식, 노란색(#EAB308) 마름모 헤드로 시각적 구분
- [ ] 오늘의 학습 사이드바 — 가격 요약 카드 / 예측 버튼(비로그인·미예측·완료 3가지 상태) / 관련 뉴스 목록(태그, 원문 새탭) 구현
- [ ] 라우팅 연동 — `/chart/:stockCode/today-learning` 신규 라우트 추가, 데스크톱은 우측 패널 교체, 모바일은 탭 전환 방식으로 분기 처리

### 🔍 주안점 & 리뷰 포인트

- `LightweightCandleChart`에 학습 핀 추가 시 `volSeries.priceToCoordinate(bar.volume)`를 사용해 이벤트 핀과 동일한 Y 기준으로 정렬했습니다. 스크롤·리사이즈 시 `renderAll()` 구독으로 재렌더링되는 방식이 적절한지 확인 부탁드립니다.
- `TodayLearningPage`(우측 패널 래퍼)에서 `stockCode → stockId` 변환을 `fetchStockSearch`로 직접 처리합니다. `StockDetailMain`과 중복 호출이 발생하는 구조인데, 공유 방법이 있다면 제안 부탁드립니다.
- `changeRate`, `priceClose`, `prediction` 필드는 키 자체가 없는 방식으로 생략되므로 `=== undefined` 체크로 처리했습니다.

### 🖼️ 스크린샷 / 테스트 결과 (선택 사항)
<!-- 직접 캡처 후 첨부 -->

---

## 🛠️ PR 유형
- [x] ✨ 새로운 기능 추가

## 🧪 영향 범위 및 테스트 (Impact & Tests)

### **영향을 받는 모듈/컴포넌트:** 
`LightweightCandleChart`, `StockDetailMain`, `AppRouter`, `news` feature (types / api / hooks / components)

### **테스트 방법:**
- [x] 수동 API 테스트 (Postman/Swagger)

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 불필요한 로그나 주석을 제거했습니다.
- [x] 관련 이슈를 연결했습니다.