### PR TITLE
Feature/100 prediction api

### DIFF
--- a/src/features/news/components/TodayLearningSidebar.tsx
+++ b/src/features/news/components/TodayLearningSidebar.tsx
@@ -1,5 +1,9 @@
+import { useState } from 'react';
+import { useUpsertPrediction } from '@/features/prediction/hooks/useUpsertPrediction';
+import type { PredictionDirection } from '@/features/prediction/types/prediction.types';
 import { useTodayLearning } from '@/features/news/hooks/useTodayLearning';
 import type { PredictionInfo } from '@/features/news/types/news.types';
+import { getApiResponseCode } from '@/features/auth/api/authApi';
 
 interface TodayLearningSidebarProps {
   stockId: number | undefined;
@@ -49,26 +53,41 @@ const DIRECTION_OPTIONS = [
 interface PredictionSectionProps {
   isLoggedIn: boolean;
   prediction: PredictionInfo | undefined;
+  isPending: boolean;
+  pendingDirection: PredictionDirection | null;
   onLoginRequired: () => void;
+  onPredict: (direction: PredictionDirection) => void;
 }
 
-function PredictionSection({ isLoggedIn, prediction, onLoginRequired }: PredictionSectionProps) {
+function PredictionSection({
+  isLoggedIn,
+  prediction,
+  isPending,
+  pendingDirection,
+  onLoginRequired,
+  onPredict,
+}: PredictionSectionProps) {
   return (
     <div className="rounded-[10px] p-4 mb-4" style={{ background: '#fff', border: '1px solid #e5e7eb' }}>
       <p className="text-[13px] font-semibold text-[#374151] mb-3">오를까? 내릴까?</p>
       <div className="grid grid-cols-3 gap-2">
         {DIRECTION_OPTIONS.map(({ value, label, Icon, activeColor, activeBg }) => {
-          // 예측 완료: 해당 방향 활성화, 나머지 비활성
-          const isDone = isLoggedIn && prediction !== undefined;
-          const isActive = isDone && prediction.direction === value;
-          const isDisabled = isDone && prediction.direction !== value;
+          const isActive = isLoggedIn && prediction?.direction === value;
+          const isDisabled = isPending;
+          const isThisPending = isPending && pendingDirection === value;
 
           return (
             <button
               key={value}
               type="button"
-              disabled={isDisabled}
-              onClick={!isLoggedIn ? onLoginRequired : undefined}
+              disabled={isDisabled || isPending}
+              onClick={() => {
+                if (!isLoggedIn) {
+                  onLoginRequired();
+                  return;
+                }
+                onPredict(value);
+              }}
               className="flex flex-col items-center gap-1.5 py-3 rounded-[10px] transition-all active:opacity-70 disabled:opacity-40"
               style={
                 isActive
@@ -76,7 +95,13 @@ function PredictionSection({ isLoggedIn, prediction, onLoginRequired }: Predicti
                   : { color: '#9ca3af', background: '#f9fafb', border: '1.5px solid #e5e7eb' }
               }
             >
-              <Icon />
+              {isThisPending ? (
+                <div className="w-[26px] h-[26px] flex items-center justify-center">
+                  <div className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                </div>
+              ) : (
+                <Icon />
+              )}
               <span className="text-[13px] font-semibold">{label}</span>
             </button>
           );
@@ -100,7 +125,29 @@ export default function TodayLearningSidebar({
   isLoggedIn,
   onLoginRequired,
 }: TodayLearningSidebarProps) {
-  const { data, isLoading, isError } = useTodayLearning(stockId, isOpen);
+  const { data, isLoading, isError, refetch } = useTodayLearning(stockId, isOpen);
+  const { mutate: upsertPrediction, isPending, variables } = useUpsertPrediction();
+  const [predictError, setPredictError] = useState<string | null>(null);
+
+  const pendingDirection = isPending ? (variables?.direction ?? null) : null;
+
+  function handlePredict(direction: PredictionDirection) {
+    if (!data || stockId == null) return;
+    setPredictError(null);
+    upsertPrediction(
+      { digestId: data.digestId, stockId, direction },
+      {
+        onSuccess: () => void refetch(),
+        onError: (error) => {
+          const code = getApiResponseCode(error);
+          if (code === 4031) setPredictError('오늘의 학습에서만 예측할 수 있습니다.');
+          else if (code === 4030) setPredictError('학습 정보를 찾을 수 없습니다.');
+          else if (code === 4032) setPredictError('종목 정보를 찾을 수 없습니다.');
+          else setPredictError('예측 등록에 실패했습니다. 다시 시도해 주세요.');
+        },
+      },
+    );
+  }
 
   if (!isOpen) return null;
 
@@ -177,8 +224,16 @@ export default function TodayLearningSidebar({
             <PredictionSection
               isLoggedIn={isLoggedIn}
               prediction={data.prediction}
+              isPending={isPending}
+              pendingDirection={pendingDirection}
               onLoginRequired={onLoginRequired}
+              onPredict={handlePredict}
             />
+            {predictError && (
+              <p className="-mt-2 mb-3 rounded-lg bg-[#FFF0F0] px-3 py-2 text-[12px] text-[#e03131]">
+                {predictError}
+              </p>
+            )}
 
             {/* 섹션 C — 관련 뉴스 */}
             <div className="mb-4">

--- a/src/features/news/hooks/useTodayLearning.ts
+++ b/src/features/news/hooks/useTodayLearning.ts
@@ -3,7 +3,7 @@ import { fetchTodayLearning } from '@/features/news/api/learningApi';
 import { stockLearningKeys } from '@/shared/queryKeys';
 
 export function useTodayLearning(stockId: number | undefined, enabled: boolean) {
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading, isError, refetch } = useQuery({
     queryKey: stockLearningKeys.today(stockId ?? 0),
     queryFn: () => fetchTodayLearning(stockId!),
     enabled: enabled && stockId != null && stockId > 0,
@@ -14,5 +14,6 @@ export function useTodayLearning(stockId: number | undefined, enabled: boolean) 
     data: data ?? null,
     isLoading,
     isError,
+    refetch,
   };
 }

--- a/src/features/news/types/news.types.ts
+++ b/src/features/news/types/news.types.ts
@@ -39,6 +39,7 @@ export interface LearningNewsItem {
 }
 
 export interface TodayLearningResult {
+  digestId: number;
   digestDate: string;          // "yyyy.MM.dd (요일)"
   stockName: string;
   changeRate?: string;         // "+1.23%" / "-2.76%", 키 자체가 없을 수 있음

--- a/src/features/prediction/api/predictionApi.ts
+++ b/src/features/prediction/api/predictionApi.ts
@@ -1,0 +1,53 @@
+import apiClient from '@/shared/api/axios';
+import type {
+  MyStatsDto,
+  PredictionDto,
+  PredictionPageResult,
+  PredictionStatusDto,
+  UpsertPredictionBody,
+  WeeklySummaryDto,
+} from '../types/prediction.types';
+
+type BaseResponse<T> = {
+  isSuccess: boolean;
+  responseCode: number;
+  responseMessage: string;
+  result: T;
+};
+
+export async function upsertPrediction(body: UpsertPredictionBody): Promise<PredictionDto> {
+  const res = await apiClient.post<BaseResponse<PredictionDto>>('/api/predictions', body);
+  return res.data.result;
+}
+
+export async function getPredictionStatus(
+  digestId: number,
+  stockId: number,
+): Promise<PredictionStatusDto> {
+  const res = await apiClient.get<BaseResponse<PredictionStatusDto>>(
+    `/api/predictions/digest/${digestId}/stocks/${stockId}`,
+  );
+  return res.data.result;
+}
+
+export async function getPredictions(
+  cursor?: number,
+  size = 10,
+): Promise<PredictionPageResult> {
+  const params: Record<string, unknown> = { size };
+  if (cursor !== undefined) params.cursor = cursor;
+  const res = await apiClient.get<BaseResponse<PredictionPageResult>>('/api/predictions', {
+    params,
+  });
+  return res.data.result;
+}
+
+export async function getMyStats(): Promise<MyStatsDto> {
+  const res = await apiClient.get<BaseResponse<MyStatsDto>>('/api/me/stats');
+  return res.data.result;
+}
+
+export async function getWeeklySummary(): Promise<WeeklySummaryDto> {
+  const res = await apiClient.get<BaseResponse<WeeklySummaryDto>>('/api/me/weekly-summary');
+  return res.data.result;
+}

--- a/src/features/prediction/hooks/useMyStats.ts
+++ b/src/features/prediction/hooks/useMyStats.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { getMyStats } from '../api/predictionApi';
+import { predictionKeys } from '@/shared/queryKeys';
+
+export function useMyStats() {
+  return useQuery({
+    queryKey: predictionKeys.myStats(),
+    queryFn: getMyStats,
+  });
+}

--- a/src/features/prediction/hooks/usePredictionStatus.ts
+++ b/src/features/prediction/hooks/usePredictionStatus.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { getPredictionStatus } from '../api/predictionApi';
+import { predictionKeys } from '@/shared/queryKeys';
+
+export function usePredictionStatus(digestId: number, stockId: number) {
+  return useQuery({
+    queryKey: predictionKeys.status(digestId, stockId),
+    queryFn: () => getPredictionStatus(digestId, stockId),
+    enabled: digestId > 0 && stockId > 0,
+  });
+}

--- a/src/features/prediction/hooks/usePredictions.ts
+++ b/src/features/prediction/hooks/usePredictions.ts
@@ -1,0 +1,14 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { getPredictions } from '../api/predictionApi';
+import { predictionKeys } from '@/shared/queryKeys';
+
+export function usePredictions(size = 10) {
+  return useInfiniteQuery({
+    queryKey: predictionKeys.list(undefined, size),
+    queryFn: ({ pageParam }) =>
+      getPredictions(pageParam as number | undefined, size),
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) =>
+      lastPage.hasNext ? (lastPage.nextCursor ?? undefined) : undefined,
+  });
+}

--- a/src/features/prediction/hooks/useUpsertPrediction.ts
+++ b/src/features/prediction/hooks/useUpsertPrediction.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { upsertPrediction } from '../api/predictionApi';
+import { predictionKeys } from '@/shared/queryKeys';
+import type { UpsertPredictionBody } from '../types/prediction.types';
+
+export function useUpsertPrediction() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: UpsertPredictionBody) => upsertPrediction(body),
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: predictionKeys.status(variables.digestId, variables.stockId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: predictionKeys.lists(),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: predictionKeys.myStats(),
+      });
+    },
+  });
+}

--- a/src/features/prediction/hooks/useWeeklySummary.ts
+++ b/src/features/prediction/hooks/useWeeklySummary.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { getWeeklySummary } from '../api/predictionApi';
+import { predictionKeys } from '@/shared/queryKeys';
+
+export function useWeeklySummary() {
+  return useQuery({
+    queryKey: predictionKeys.weeklySummary(),
+    queryFn: getWeeklySummary,
+  });
+}

--- a/src/features/prediction/types/prediction.types.ts
+++ b/src/features/prediction/types/prediction.types.ts
@@ -1,0 +1,54 @@
+export type PredictionDirection = 'UP' | 'DOWN' | 'SIDEWAYS';
+
+export interface PredictionDto {
+  id: number;
+  digestId: number;
+  stockId: number;
+  stockName: string;
+  stockTicker: string;
+  stockLogoUrl: string | null;
+  direction: PredictionDirection;
+  reason: string | null;
+  actualChangePct: number | null;
+  isCorrect: boolean | null;
+  createdAt: string;
+  reviewedAt: string | null;
+}
+
+export interface PredictionStatusDto {
+  id: number | null;
+  direction: PredictionDirection | null;
+  reason: string | null;
+  canPredict: boolean;
+}
+
+export interface PredictionGroup {
+  digestDate: string;
+  predictions: PredictionDto[];
+}
+
+export interface PredictionPageResult {
+  groups: PredictionGroup[];
+  nextCursor: number | null;
+  hasNext: boolean;
+}
+
+export interface UpsertPredictionBody {
+  digestId: number;
+  stockId: number;
+  direction: PredictionDirection;
+  reason?: string;
+}
+
+export interface MyStatsDto {
+  totalPredictions: number;
+  correctPredictions: number;
+  predictionAccuracy: number | null;
+  totalScraps: number;
+}
+
+export interface WeeklySummaryDto {
+  weeklyTotal: number;
+  weeklyCorrect: number;
+  weeklyAccuracy: number | null;
+}

--- a/src/pages/MyPage/components/MyPageAlarmTab.tsx
+++ b/src/pages/MyPage/components/MyPageAlarmTab.tsx
@@ -1,42 +1,26 @@
 import { Fragment, useMemo, useState } from 'react';
-import { MY_PAGE_ALARM_HISTORY } from './myPage.mock';
-import type { AlarmGroup, AlarmItemRow, AlarmTag } from './myPage.types';
+import bellAlarmSrc from '@/assets/Bell_alarm.svg';
+import { notificationDetailToAlertGroups, isTodayNotifiedDate } from '@/features/alert/AlertCenter/alertCenterDetailAdapter';
+import AlertStockAvatar from '@/features/alert/AlertCenter/AlertStockAvatar';
+import { useNotificationDetail } from '@/features/alert/hooks/useNotificationDetail';
+import { useMarkNotificationRead } from '@/features/alert/hooks/useNotificationMutations';
+import { useNotificationSummary } from '@/features/alert/hooks/useNotificationSummary';
+import type { AlertGroup, AlertItemRow, AlertTag } from '@/features/alert/AlertCenter/alertCenter.types';
 import MyPageSearchPlaceholder from './MyPageSearchPlaceholder';
-import MyPageStockAvatar from './MyPageStockAvatar';
 
-function groupAlarmsByDate(rows: AlarmGroup[]): { date: string; isToday: boolean; groups: AlarmGroup[] }[] {
-  const map = new Map<string, AlarmGroup[]>();
-  for (const r of rows) {
-    const list = map.get(r.date);
-    if (list) list.push(r);
-    else map.set(r.date, [r]);
-  }
-  return [...map.entries()]
-    .sort((a, b) => b[0].localeCompare(a[0]))
-    .map(([date, groups]) => ({
-      date,
-      groups,
-      isToday: groups.some((g) => g.isToday),
-    }));
-}
+type AlarmSubTab = 'all' | 'detail';
 
-/** 알림센터 세부(`AlertCenterDetailFeed` TagChip)와 동일 */
-function AlarmTagChip({ tag }: { tag: AlarmTag }) {
-  if (tag.variant === 'outline') {
-    return (
-      <span className="rounded-md border border-[#C7DBFF] bg-[#F4F6FB] px-2 py-0.5 text-[10px] text-[#014D9D]">
-        {tag.label}
-      </span>
-    );
-  }
+// ─── 공통 서브 컴포넌트 ────────────────────────────────────────────────────────
+
+function TagChip({ tag }: { tag: AlertTag }) {
   return (
     <span className="rounded-md border border-[#C7DBFF] bg-[#F4F6FB] px-2 py-0.5 text-[10px] font-medium text-[#014D9D]">
-      {tag.label}
+      #{tag.label}
     </span>
   );
 }
 
-function AlarmEventContent({ item }: { item: AlarmItemRow }) {
+function EventContent({ item }: { item: AlertItemRow }) {
   return (
     <div className="min-w-0">
       <div className="text-[12px] leading-snug">
@@ -46,7 +30,7 @@ function AlarmEventContent({ item }: { item: AlarmItemRow }) {
       {item.tags && item.tags.length > 0 && (
         <div className="mt-2 flex flex-wrap gap-1.5">
           {item.tags.map((tag) => (
-            <AlarmTagChip key={`${item.headline}-${tag.label}`} tag={tag} />
+            <TagChip key={`${item.headline}-${tag.label}`} tag={tag} />
           ))}
         </div>
       )}
@@ -54,53 +38,129 @@ function AlarmEventContent({ item }: { item: AlarmItemRow }) {
   );
 }
 
-export default function MyPageAlarmTab() {
-  const [searchQuery, setSearchQuery] = useState('');
-  const filteredGroups = useMemo(() => {
+// ─── 전체 탭 ─────────────────────────────────────────────────────────────────
+
+interface AllTabProps {
+  searchQuery: string;
+  onSelectNotification: (id: number) => void;
+}
+
+function AllTab({ searchQuery, onSelectNotification }: AllTabProps) {
+  const { data: summaryList, isLoading } = useNotificationSummary();
+  const { mutate: markRead } = useMarkNotificationRead();
+
+  const filtered = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
-    if (!q) return MY_PAGE_ALARM_HISTORY;
-
-    return MY_PAGE_ALARM_HISTORY.filter((group) => {
-      const groupText = [group.name, group.code, group.summaryLine ?? '', group.date].join(' ').toLowerCase();
-      const itemText = group.items
-        .flatMap((item) => [
-          item.headline,
-          item.desc,
-          ...(item.tags?.map((t) => t.label) ?? []),
-        ])
+    if (!q) return summaryList;
+    return summaryList.filter((item) =>
+      [item.stockNames, item.message, item.relativeTime, item.date]
         .join(' ')
-        .toLowerCase();
-      return `${groupText} ${itemText}`.includes(q);
-    });
-  }, [searchQuery]);
-  const sections = useMemo(() => groupAlarmsByDate(filteredGroups), [filteredGroups]);
-  const [readStateByGroup, setReadStateByGroup] = useState<Record<string, boolean>>({});
+        .toLowerCase()
+        .includes(q),
+    );
+  }, [summaryList, searchQuery]);
 
-  const allSections = useMemo(() => groupAlarmsByDate(MY_PAGE_ALARM_HISTORY), []);
-  const allGroupKeys = useMemo(() => {
-    const keys: string[] = [];
-    for (const s of allSections) {
-      s.groups.forEach((g) => keys.push(`${s.date}-${g.code}`));
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[120px] items-center justify-center text-[13px] text-[#9ca3af]">
+        불러오는 중...
+      </div>
+    );
+  }
+
+  if (filtered.length === 0) {
+    return (
+      <div className="flex min-h-[120px] items-center justify-center text-[13px] text-[#9ca3af]">
+        {searchQuery ? '검색 결과가 없습니다.' : '최근 알림이 없습니다.'}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {filtered.map((item) => (
+        <button
+          key={item.notificationId}
+          type="button"
+          onClick={() => {
+            markRead(item.notificationId);
+            onSelectNotification(item.notificationId);
+          }}
+          className={`mypage-scrap-kr flex min-h-[81px] w-full shrink-0 cursor-pointer items-center gap-3 border-b border-[#f3f4f6] px-[21px] text-left transition-colors hover:bg-[#F0F2F8] ${
+            item.isRead ? 'bg-[#F0F2F8]' : ''
+          }`}
+        >
+          <div className="flex h-9 w-9 shrink-0 -translate-y-1 items-center justify-center rounded-lg bg-[#f3f4f6]">
+            <img src={bellAlarmSrc} alt="" aria-hidden className="h-6 w-6" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-[12px] leading-snug text-[#111827]">
+              {item.message.split(/\*\*(.*?)\*\*/g).map((part, i) =>
+                i % 2 === 1 ? <strong key={i}>{part}</strong> : part,
+              )}
+            </div>
+            <div className="mt-1 text-[11px] leading-snug text-[#9ca3af]">{item.relativeTime}</div>
+          </div>
+        </button>
+      ))}
+    </>
+  );
+}
+
+// ─── 세부 알림 탭 ─────────────────────────────────────────────────────────────
+
+interface DetailTabProps {
+  selectedNotificationId: number | null;
+}
+
+function DetailTab({ selectedNotificationId }: DetailTabProps) {
+  const [collapsedByGroup, setCollapsedByGroup] = useState<Record<string, boolean>>({});
+  const { data: allDetails, isLoading } = useNotificationDetail();
+
+  const sections = useMemo(() => {
+    if (selectedNotificationId != null) {
+      const detail = allDetails.find((n) => n.notificationId === selectedNotificationId) ?? null;
+      if (!detail) return [];
+      return [{ date: detail.date, isToday: isTodayNotifiedDate(detail.date), groups: notificationDetailToAlertGroups(detail) }];
     }
-    return keys;
-  }, [allSections]);
 
-  const isAllRead = allGroupKeys.length > 0 && allGroupKeys.every((k) => readStateByGroup[k]);
+    // 전체 알림을 날짜별로 그룹핑
+    const dateMap = new Map<string, AlertGroup[]>();
+    for (const detail of allDetails) {
+      const groups = notificationDetailToAlertGroups(detail);
+      const existing = dateMap.get(detail.date);
+      if (existing) existing.push(...groups);
+      else dateMap.set(detail.date, [...groups]);
+    }
+    return [...dateMap.entries()]
+      .sort((a, b) => b[0].localeCompare(a[0]))
+      .map(([date, groups]) => ({ date, groups, isToday: isTodayNotifiedDate(date) }));
+  }, [allDetails, selectedNotificationId]);
 
   const getGroupKey = (date: string, code: string) => `${date}-${code}`;
 
-  return (
-    <div className="mypage-scrap-kr w-full overflow-x-hidden px-[21px] py-4">
-      <MyPageSearchPlaceholder
-        placeholder="종목명, 이벤트 검색"
-        value={searchQuery}
-        onChange={setSearchQuery}
-      />
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[120px] items-center justify-center text-[13px] text-[#9ca3af]">
+        불러오는 중...
+      </div>
+    );
+  }
 
-      <div className="mt-1 flex flex-col gap-4">
-        {sections.map(({ date, isToday, groups }, dateIdx) => (
+  if (sections.length === 0) {
+    return (
+      <div className="mypage-scrap-kr flex min-h-[120px] items-center justify-center px-[21px] pt-4 text-center text-[13px] text-[#9ca3af]">
+        {selectedNotificationId != null ? '알림을 선택하면 세부 내용이 표시됩니다.' : '세부 알림이 없습니다.'}
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full overflow-x-hidden px-[21px] pb-4 pt-4">
+      <div className="flex flex-col gap-4">
+        {sections.map(({ date, isToday, groups }) => (
           <section key={date} className="flex flex-col gap-0">
-            <div className="-mx-[21px] flex items-center justify-between gap-3 border-b border-[#e5e7eb] px-[21px] pb-2.5">
+            <div className="-mx-[21px] flex items-center gap-3 border-b border-[#e5e7eb] px-[21px] pb-2.5">
               <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
                 <h3 className="mypage-inter text-[12px] font-bold text-[#6b7280]">{date}</h3>
                 {isToday && (
@@ -109,120 +169,142 @@ export default function MyPageAlarmTab() {
                   </span>
                 )}
               </div>
-              {dateIdx === 0 && (
-                <button
-                  type="button"
-                  onClick={() =>
-                    setReadStateByGroup(() => {
-                      const next: Record<string, boolean> = {};
-                      allGroupKeys.forEach((k) => {
-                        next[k] = true;
-                      });
-                      return next;
-                    })
-                  }
-                  className={`shrink-0 border-0 bg-transparent p-0 text-[12px] font-bold ${
-                    isAllRead ? 'text-[#9ca3af]' : 'text-[#014d9d]'
-                  }`}
-                >
-                  {isAllRead ? '전체 읽음' : '전체 읽음 처리'}
-                </button>
-              )}
             </div>
 
             <div className="relative flex flex-col">
-              {groups.map((group, idx) => (
-                <Fragment key={`${group.code}-${date}-${idx}`}>
-                  {(() => {
-                    const groupKey = getGroupKey(date, group.code);
-                    const isRead = !!readStateByGroup[groupKey];
-                    return (
-                      <>
-                  <div className="relative z-10 border-b border-[#f3f4f6] last:border-b-0">
-                    <div className="-mx-[21px] flex w-[calc(100%+42px)] items-center gap-3 px-[21px] py-3 transition-colors hover:bg-[#F0F2F8]">
-                      <div className="relative shrink-0">
-                        <MyPageStockAvatar color={group.color} ini={group.ini} />
-                        {!isRead && (
-                          <span
-                            className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[9px] font-bold text-white shadow-sm"
-                            style={{ backgroundColor: group.badgeColor }}
-                          >
-                            {group.items.length}
-                          </span>
-                        )}
-                      </div>
-
-                      <div className="min-w-0 flex-1">
-                        <div className="flex items-center gap-2">
-                          <div className="min-w-0">
-                            <div className="flex flex-wrap items-baseline gap-x-1.5 gap-y-0.5">
-                              <span className="text-[13px] font-bold text-[#111827]">{group.name}</span>
-                              <span className="font-mono text-[11px] text-[#9ca3af]">{group.code}</span>
-                            </div>
-                            {group.summaryLine && (
-                              <div className="mt-0 text-[11px] leading-4 text-[#6b7280]">
-                                {group.summaryLine}
-                              </div>
-                            )}
-                          </div>
+              {groups.map((group: AlertGroup, idx: number) => {
+                const groupKey = getGroupKey(date, group.code);
+                const isCollapsed = collapsedByGroup[groupKey] !== false;
+                return (
+                  <Fragment key={`${group.code}-${date}-${idx}`}>
+                    <div className="relative z-10 border-b border-[#f3f4f6] last:border-b-0">
+                      <div
+                        className="-mx-[21px] flex w-[calc(100%+42px)] cursor-pointer items-center gap-3 px-[21px] py-3 transition-colors hover:bg-[#F0F2F8]"
+                        onClick={() =>
+                          setCollapsedByGroup((prev) => ({
+                            ...prev,
+                            [groupKey]: !isCollapsed,
+                          }))
+                        }
+                      >
+                        <div className="relative shrink-0">
+                          <AlertStockAvatar color={group.color} ini={group.ini} logoUrl={group.logoUrl} />
                         </div>
-                      </div>
-                    </div>
 
-                    <div className="-mx-[21px] h-[0.5px] bg-[#e5e7eb]" aria-hidden />
-                  </div>
+                        <div className="min-w-0 flex-1">
+                          <div className="flex min-w-0 flex-wrap items-baseline gap-x-1.5 gap-y-0.5">
+                            <span className="text-[13px] font-bold text-[#111827]">{group.name}</span>
+                            <span className="font-mono text-[11px] text-[#9ca3af]">{group.code}</span>
+                          </div>
+                          {group.summaryLine && (
+                            <div className="mt-0 text-[11px] leading-4 text-[#6b7280]">{group.summaryLine}</div>
+                          )}
+                        </div>
 
-                  <div
-                    className={`relative z-10 -mx-[21px] px-[21px] border-b border-[#f3f4f6] last:border-b-0 ${
-                      isRead ? 'bg-[#F0F2F8]' : 'bg-white'
-                    }`}
-                  >
-                    <div className="relative flex flex-col">
-                      <div className="absolute top-0 bottom-0 left-[-2px] z-30 w-[2px] bg-[#D8E2F8]" aria-hidden />
-                      {group.items.map((item, idx) => (
-                        <div
-                          key={`${group.code}-${idx}`}
-                          className="relative -mx-[21px] flex w-[calc(100%+42px)] items-stretch gap-2.5 px-[21px] py-2 transition-colors hover:bg-[#F0F2F8]"
+                        <span
+                          className={`shrink-0 text-[10px] text-[#9ca3af] transition-transform duration-200 ${
+                            isCollapsed ? '' : 'rotate-180'
+                          }`}
                         >
-                          <div className="flex w-4 shrink-0 flex-col items-center">
-                            <span
-                              className="relative z-30 -ml-[17px] mt-1 h-1.5 w-1.5 shrink-0 rounded-full ring-3 ring-white"
-                              style={{ backgroundColor: item.dotColor }}
-                              aria-hidden
-                            />
-                          </div>
-                          <div className="min-w-0 flex-1">
-                            <AlarmEventContent item={item} />
-                          </div>
-                        </div>
-                      ))}
+                          ▼
+                        </span>
+                      </div>
+
+                      <div className="-mx-[21px] h-[0.5px] bg-[#e5e7eb]" aria-hidden />
                     </div>
-                  </div>
-                  <div className="-mx-[21px] relative z-10 flex items-center justify-between gap-3 border-y border-[#f3f4f6] bg-[#F0F2F8] px-[21px] py-2.5">
-                    <span className="text-[12px] font-medium text-[#6b7280]">총 {group.items.length}건</span>
-                    <button
-                      type="button"
-                      onClick={() =>
-                        setReadStateByGroup((prev) => ({
-                          ...prev,
-                          [groupKey]: true,
-                        }))
-                      }
-                      className={`shrink-0 border-0 bg-transparent p-0 text-[12px] font-bold ${
-                        isRead ? 'text-[#9ca3af]' : 'text-[#014d9d]'
-                      }`}
-                    >
-                      {isRead ? '읽음' : '읽음 처리'}
-                    </button>
-                  </div>
-                      </>
-                    );
-                  })()}
-                </Fragment>
-              ))}
+
+                    {!isCollapsed && (
+                      <div className="relative z-10 -mx-[21px] border-b border-[#f3f4f6] bg-white px-[21px] last:border-b-0">
+                        <div className="relative flex flex-col">
+                          <div className="absolute top-0 bottom-0 left-[-2px] z-30 w-[2px] bg-[#D8E2F8]" aria-hidden />
+                          {group.items.map((item, itemIdx) => (
+                            <div
+                              key={`${group.code}-${itemIdx}`}
+                              className="relative -mx-[21px] flex w-[calc(100%+42px)] items-stretch gap-2.5 px-[21px] py-2 transition-colors hover:bg-[#F0F2F8]"
+                            >
+                              <div className="flex w-4 shrink-0 flex-col items-center">
+                                <span
+                                  className="relative z-30 -ml-[17px] mt-1 h-1.5 w-1.5 shrink-0 rounded-full ring-3 ring-white"
+                                  style={{ backgroundColor: item.dotColor }}
+                                  aria-hidden
+                                />
+                              </div>
+                              <div className="min-w-0 flex-1">
+                                <EventContent item={item} />
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </Fragment>
+                );
+              })}
             </div>
           </section>
         ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── 메인 컴포넌트 ─────────────────────────────────────────────────────────────
+
+export default function MyPageAlarmTab() {
+  const [subTab, setSubTab] = useState<AlarmSubTab>('all');
+  const [selectedNotificationId, setSelectedNotificationId] = useState<number | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+
+  function handleSelectNotification(id: number) {
+    setSelectedNotificationId(id);
+    setSubTab('detail');
+  }
+
+  return (
+    <div className="mypage-scrap-kr flex w-full flex-col overflow-x-hidden">
+      {/* 헤더: 검색 */}
+      <div className="shrink-0 px-[21px] pt-4 pb-2">
+        <MyPageSearchPlaceholder
+          placeholder="종목명, 이벤트 검색"
+          value={searchQuery}
+          onChange={setSearchQuery}
+        />
+      </div>
+
+      {/* 서브탭 */}
+      <div className="grid w-full shrink-0 grid-cols-2 border-b border-[#e5e7eb]">
+        <button
+          type="button"
+          onClick={() => setSubTab('all')}
+          className={`mypage-scrap-kr -mb-px cursor-pointer border-0 border-b-[2.5px] bg-transparent py-3 text-center text-[13px] transition-colors ${
+            subTab === 'all'
+              ? 'border-[#014d9d] font-bold text-[#014d9d]'
+              : 'border-transparent font-medium text-[#9ca3af]'
+          }`}
+        >
+          전체
+        </button>
+        <button
+          type="button"
+          onClick={() => setSubTab('detail')}
+          className={`mypage-scrap-kr -mb-px cursor-pointer border-0 border-b-[2.5px] bg-transparent py-3 text-center text-[13px] transition-colors ${
+            subTab === 'detail'
+              ? 'border-[#014d9d] font-bold text-[#014d9d]'
+              : 'border-transparent font-medium text-[#9ca3af]'
+          }`}
+        >
+          세부 알림
+        </button>
+      </div>
+
+      {/* 탭 콘텐츠 */}
+      <div className="min-h-0 flex-1">
+        {subTab === 'all' ? (
+          <AllTab searchQuery={searchQuery} onSelectNotification={handleSelectNotification} />
+        ) : (
+          <DetailTab selectedNotificationId={selectedNotificationId} />
+        )}
       </div>
     </div>
   );

--- a/src/pages/MyPage/components/MyPagePanel.tsx
+++ b/src/pages/MyPage/components/MyPagePanel.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router';
 import logoutButtonImg from '@/assets/logoutButton.svg';
 import { getApiResponseCode, updateMyNickname } from '@/features/auth/api/authApi';
 import { useAuth } from '@/features/auth/context/AuthContext';
+import { useMyStats } from '@/features/prediction/hooks/useMyStats';
 import type { MyPageTabKey } from './myPage.types';
 import MyPageAlarmTab from './MyPageAlarmTab';
 import MyPageReviewTab from './MyPageReviewTab';
@@ -41,6 +42,8 @@ export default function MyPagePanel({ onClose, onLogout, onWithdraw, withdrawMes
   const [isWithdrawing, setIsWithdrawing] = useState(false);
   const [nicknameMessage, setNicknameMessage] = useState('');
   const [nicknameMessageType, setNicknameMessageType] = useState<'success' | 'error' | ''>('');
+
+  const { data: stats } = useMyStats();
 
   const displayNickname = nickname || user?.nickname || '사용자';
   const displayEmail = user?.email || '';
@@ -210,11 +213,16 @@ export default function MyPagePanel({ onClose, onLogout, onWithdraw, withdrawMes
             </div>
 
             <div className="grid w-full grid-cols-3 border-t border-[#e5e7eb]">
-              {[
-                ['75%', '예측 정답률'],
-                ['100', '총 예측'],
-                ['12', '스크랩'],
-              ].map(([val, label], i) => (
+              {([
+                [
+                  stats?.predictionAccuracy !== null && stats?.predictionAccuracy !== undefined
+                    ? `${stats.predictionAccuracy.toFixed(1)}%`
+                    : '-',
+                  '예측 정답률',
+                ],
+                [stats?.totalPredictions?.toString() ?? '-', '총 예측'],
+                [stats?.totalScraps?.toString() ?? '-', '스크랩'],
+              ] as [string, string][]).map(([val, label], i) => (
                   <div
                       key={label}
                       className={`py-3 text-center ${i < 2 ? 'border-r border-[#e5e7eb]' : ''}`}

--- a/src/pages/MyPage/components/MyPageReviewTab.tsx
+++ b/src/pages/MyPage/components/MyPageReviewTab.tsx
@@ -1,11 +1,41 @@
-import { useMemo } from 'react';
 import logoHappy from '@/assets/logo_happy.svg';
-import { MY_PAGE_REVIEW_DATA } from './myPage.mock';
-import type { ReviewItem } from './myPage.types';
+import { usePredictions } from '@/features/prediction/hooks/usePredictions';
+import { useWeeklySummary } from '@/features/prediction/hooks/useWeeklySummary';
+import type { PredictionDirection, PredictionDto } from '@/features/prediction/types/prediction.types';
 
 const interNums = { fontFamily: 'Inter, "Pretendard Variable", Pretendard, sans-serif' } as const;
 
-function ReviewAvatar({ initials, bg }: { initials: string; bg: string }) {
+const AVATAR_COLORS = [
+  '#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6',
+  '#EC4899', '#14B8A6', '#F97316', '#6366F1', '#84CC16',
+];
+
+function getAvatarColor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length];
+}
+
+function getInitials(name: string): string {
+  if (name.length >= 2 && /^[A-Za-z]/.test(name)) return name.slice(0, 2);
+  return Array.from(name.trim()).slice(0, 1).join('');
+}
+
+/** "2026-03-31" → "2026.03.31" */
+function formatDigestDate(date: string): string {
+  return date.replace(/-/g, '.');
+}
+
+function ReviewAvatar({ initials, bg, logoUrl }: { initials: string; bg: string; logoUrl?: string | null }) {
+  if (logoUrl) {
+    return (
+      <img
+        src={logoUrl}
+        alt=""
+        className="h-7 w-7 shrink-0 rounded-[7px] object-cover"
+      />
+    );
+  }
   return (
     <div
       className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[7px] text-[9px] font-black leading-[13.5px] text-white"
@@ -23,54 +53,126 @@ function changeRateColorClass(chg: string): string {
   return 'text-[#111827]';
 }
 
-function PredictionLabel({ prediction }: { prediction: string }) {
-  if (prediction === '상승예측') {
+function directionLabel(direction: PredictionDirection): string {
+  if (direction === 'UP') return '상승예측';
+  if (direction === 'DOWN') return '하락예측';
+  return '횡보예측';
+}
+
+function formatChangePct(pct: number | null): string {
+  if (pct === null) return '-';
+  const sign = pct > 0 ? '+' : '';
+  return `${sign}${pct.toFixed(2)}%`;
+}
+
+function rowBg(isCorrect: boolean | null): string {
+  if (isCorrect === true) return '#f0fdf4';
+  if (isCorrect === false) return '#fef2f2';
+  return '#fff';
+}
+
+function PredictionLabel({ direction }: { direction: PredictionDirection }) {
+  if (direction === 'UP') {
     return (
       <div className="text-[11px] font-medium leading-4 text-emerald-600">
         상승예측 <span aria-hidden>▲</span>
       </div>
     );
   }
-  if (prediction === '하락예측') {
+  if (direction === 'DOWN') {
     return (
       <div className="text-[11px] font-medium leading-4 text-red-600">
         하락예측 <span aria-hidden>▼</span>
       </div>
     );
   }
-  if (prediction === '횡보예측') {
-    return (
-      <div className="text-[11px] font-medium leading-4 text-[#6b7280]">
-        횡보예측 <span aria-hidden>—</span>
-      </div>
-    );
-  }
-  return <div className="text-[11px] leading-4 text-[#6b7280]">{prediction}</div>;
+  return (
+    <div className="text-[11px] font-medium leading-4 text-[#6b7280]">
+      횡보예측 <span aria-hidden>—</span>
+    </div>
+  );
 }
 
-function groupReviewByDate(rows: ReviewItem[]): { date: string; items: ReviewItem[] }[] {
-  const map = new Map<string, ReviewItem[]>();
-  for (const r of rows) {
-    const list = map.get(r.date);
-    if (list) list.push(r);
-    else map.set(r.date, [r]);
-  }
-  return [...map.entries()]
-    .sort((a, b) => b[0].localeCompare(a[0]))
-    .map(([date, items]) => ({ date, items }));
+function PredictionRow({ item }: { item: PredictionDto }) {
+  const bg = rowBg(item.isCorrect);
+  const color = getAvatarColor(item.stockName);
+  const ini = getInitials(item.stockName);
+  const chg = formatChangePct(item.actualChangePct);
+  const resultLabel = item.isCorrect === true ? '적중' : item.isCorrect === false ? '미적중' : '집계 중';
+  const resultPending = item.isCorrect === null;
+
+  return (
+    <div
+      className="flex h-auto w-full items-center justify-between border-b border-white px-[21px] py-3"
+      style={{ backgroundColor: bg }}
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-2.5">
+        <ReviewAvatar initials={ini} bg={color} logoUrl={item.stockLogoUrl} />
+        <div className="min-w-0">
+          <div className="text-[12.5px] font-bold leading-[18.75px] text-[#111827]">{item.stockName}</div>
+          <PredictionLabel direction={item.direction} />
+        </div>
+      </div>
+      <div className="flex shrink-0 flex-col items-end gap-0.5 text-right">
+        <span
+          className={`-mt-0.5 inline-flex items-center justify-center rounded-full px-2 py-0.5 text-[11px] font-bold ${
+            resultPending
+              ? 'bg-[#f3f4f6] text-[#6b7280]'
+              : item.isCorrect
+                ? 'bg-[#DCFCE7] text-emerald-900'
+                : 'bg-[#FEE2E2] text-red-900'
+          }`}
+        >
+          {resultLabel}
+        </span>
+        <div
+          className={`mypage-scrap-kr text-[10.5px] font-semibold leading-[15.75px] tabular-nums ${changeRateColorClass(chg)}`}
+        >
+          {chg}
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export default function MyPageReviewTab() {
-  const { total, hits, sections } = useMemo(() => {
-    const rows = MY_PAGE_REVIEW_DATA;
-    const totalCount = rows.length;
-    const hitCount = rows.filter((r) => r.result === '적중').length;
-    return {
-      total: totalCount,
-      hits: hitCount,
-      sections: groupReviewByDate(rows),
-    };
-  }, []);
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    isError,
+  } = usePredictions();
+
+  const { data: weekly } = useWeeklySummary();
+
+  const weeklyTotal = weekly?.weeklyTotal ?? 0;
+  const weeklyCorrect = weekly?.weeklyCorrect ?? 0;
+  const weeklyAccuracy =
+    weekly?.weeklyAccuracy !== null && weekly?.weeklyAccuracy !== undefined
+      ? `${weekly.weeklyAccuracy.toFixed(1)}%`
+      : weeklyTotal > 0
+        ? `${Math.round((weeklyCorrect / weeklyTotal) * 100)}%`
+        : '0%';
+
+  const groups = data?.pages.flatMap((page) => page.groups) ?? [];
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center px-[21px] py-12 text-[13px] text-[#9ca3af]">
+        불러오는 중...
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex items-center justify-center px-[21px] py-12 text-[13px] text-red-500">
+        데이터를 불러오지 못했습니다.
+      </div>
+    );
+  }
 
   return (
     <div className="px-[21px] py-4">
@@ -87,11 +189,11 @@ export default function MyPageReviewTab() {
           <span className="text-[13px] font-bold text-[#1e40af]">
             이번 주{' '}
             <span className="tabular-nums" style={interNums}>
-              {total}
+              {weeklyTotal}
             </span>
             건 중{' '}
             <span className="tabular-nums" style={interNums}>
-              {hits}
+              {weeklyCorrect}
             </span>
             건 적중했어요!
           </span>
@@ -100,59 +202,41 @@ export default function MyPageReviewTab() {
           className="inline-flex min-w-[2.75rem] shrink-0 items-center justify-center rounded-full bg-[#dbeafe] px-2.5 py-px text-center text-[13px] font-bold leading-tight tabular-nums text-[#2563eb]"
           style={interNums}
         >
-          {total > 0 ? `${Math.round((hits / total) * 100)}%` : '0%'}
+          {weeklyAccuracy}
         </span>
       </div>
 
-      <div className="flex flex-col gap-4">
-        {sections.map(({ date, items }) => (
-          <section key={date} className="flex flex-col gap-0">
-            <h3 className="-mx-[21px] border-b border-[#e5e7eb] px-[21px] pb-2.5 text-[12px] font-bold text-[#6b7280]">
-              {date}
-            </h3>
-            <div className="-mx-[21px] flex flex-col">
-              {items.map((r, i) => (
-                <div
-                  key={`${r.code}-${date}-${i}`}
-                  className="flex h-auto w-full items-center justify-between border-b border-white px-[21px] py-3"
-                  style={{ backgroundColor: r.bg || '#fff' }}
-                >
-                  <div className="flex min-w-0 flex-1 items-center gap-2.5">
-                    <ReviewAvatar initials={r.ini} bg={r.color} />
-                    <div className="min-w-0">
-                      <div className="text-[12.5px] font-bold leading-[18.75px] text-[#111827]">{r.name}</div>
-                      <PredictionLabel prediction={r.prediction} />
-                    </div>
-                  </div>
-                  <div className="flex shrink-0 flex-col items-end gap-0.5 text-right">
-                    <span
-                      className={`-mt-0.5 inline-flex items-center justify-center rounded-full px-2 py-0.5 text-[11px] font-bold ${
-                        r.result === '적중'
-                          ? 'bg-[#DCFCE7] text-emerald-900'
-                          : 'bg-[#FEE2E2] text-red-900'
-                      }`}
-                    >
-                      {r.result}
-                    </span>
-                    <div
-                      className={`mypage-scrap-kr text-[10.5px] font-semibold leading-[15.75px] tabular-nums ${changeRateColorClass(r.chg)}`}
-                    >
-                      {r.chg}
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </section>
-        ))}
-      </div>
+      {groups.length === 0 ? (
+        <div className="py-12 text-center text-[13px] text-[#9ca3af]">아직 예측 기록이 없어요.</div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {groups.map(({ digestDate, predictions }) => (
+            <section key={digestDate} className="flex flex-col gap-0">
+              <h3 className="-mx-[21px] border-b border-[#e5e7eb] px-[21px] pb-2.5 text-[12px] font-bold text-[#6b7280]">
+                {formatDigestDate(digestDate)}
+              </h3>
+              <div className="-mx-[21px] flex flex-col">
+                {predictions.map((item) => (
+                  <PredictionRow key={item.id} item={item} />
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
 
-      <button
-        type="button"
-        className="mt-4 w-full rounded-2xl border border-dashed border-[#d1d5db] bg-transparent py-2 text-[13px] font-medium text-[#6b7280] transition-colors hover:bg-[#f9fafb]"
-      >
-        + 이전 기록 더 보기
-      </button>
+      {hasNextPage && (
+        <button
+          type="button"
+          onClick={() => void fetchNextPage()}
+          disabled={isFetchingNextPage}
+          className="mt-4 w-full rounded-2xl border border-dashed border-[#d1d5db] bg-transparent py-2 text-[13px] font-medium text-[#6b7280] transition-colors hover:bg-[#f9fafb] disabled:opacity-60"
+        >
+          {isFetchingNextPage ? '불러오는 중...' : '+ 이전 기록 더 보기'}
+        </button>
+      )}
     </div>
   );
 }
+
+export { directionLabel };

--- a/src/shared/queryKeys.ts
+++ b/src/shared/queryKeys.ts
@@ -1,3 +1,13 @@
+export const predictionKeys = {
+  lists: () => ['predictions', 'list'] as const,
+  list: (cursor?: number, size?: number) =>
+    [...predictionKeys.lists(), { cursor, size }] as const,
+  status: (digestId: number, stockId: number) =>
+    ['predictions', 'status', digestId, stockId] as const,
+  myStats: () => ['me', 'stats'] as const,
+  weeklySummary: () => ['me', 'weekly-summary'] as const,
+};
+
 export const stockLearningKeys = {
   pin: (stockId: number) => ['stock', stockId, 'learning-pin'] as const,
   today: (stockId: number) => ['stock', stockId, 'today-learning'] as const,


### PR DESCRIPTION
## #️⃣ Issue Number
- Closes #100

## 📝 변경사항
예측·복기 및 마이페이지 알림 히스토리 API를 실데이터로 연동합니다.
기존 mock 데이터로 구성된 UI에 실제 백엔드 API를 연결하고, 예측 등록/수정 기능을 구현했습니다.

### 🎯 핵심 변경 사항 (Key Changes)

- [x] 예측 API 레이어 신규 추가 (타입, API 함수, TanStack Query 훅)
- [x] 마이페이지 예측 복기 탭 실데이터 연동 (무한스크롤, 주간 요약 배너, 종목 로고 이미지)
- [x] 마이페이지 통계(예측 정답률·총 예측·스크랩) 실데이터 연동
- [x] 마이페이지 알림 히스토리 탭 실데이터 연동 및 알림센터와 동일한 구조(전체/세부 알림 서브탭)로 개선
- [x] 오늘의 학습 패널 예측 버튼(상승/횡보/하락) API 연동
- [x] 예측 등록/수정 후 관련 쿼리(목록·통계) 즉시 갱신

### 🔍 주안점 & 리뷰 포인트

- `useUpsertPrediction` onSuccess 시 `predictionKeys.lists()` 상위 키로 invalidate하여 무한스크롤 쿼리 전체를 갱신합니다. `predictionKeys.list()`(exact key)로 invalidate할 경우 size 값 불일치로 갱신이 안 되는 문제가 있었습니다.
- 알림 히스토리 세부 알림 탭은 특정 알림 선택 시 해당 1건만, 미선택 시 전체 날짜 데이터를 날짜별로 그룹핑하여 표시합니다.
- 예측 버튼은 뮤테이션 pending 중에만 비활성화되며, 기존 예측이 있어도 다른 방향으로 변경(upsert) 가능합니다.

---

## 🛠️ PR 유형
- [x] ✨ 새로운 기능 추가
- [x] 🐛 버그 수정

## 🧪 영향 범위 및 테스트 (Impact & Tests)

### **영향을 받는 모듈/컴포넌트:**
- `src/features/prediction/` (신규)
- `src/features/news/` (TodayLearningSidebar, useTodayLearning, news.types)
- `src/pages/MyPage/components/` (MyPagePanel, MyPageReviewTab, MyPageAlarmTab)
- `src/shared/queryKeys.ts`

### **테스트 방법:**
- [x] 수동 API 테스트 (Postman/Swagger)

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 불필요한 로그나 주석을 제거했습니다.
- [x] 관련 이슈를 연결했습니다.
