### PR TITLE
feat(mypage):마이페이지 스크랩 탭 조회 API 분리 및 로고 아바타 fallback 적용

### DIFF
--- a/src/features/scrap/api/scrapApi.ts
+++ b/src/features/scrap/api/scrapApi.ts
@@ -16,6 +16,7 @@ export type ScrapEventDto = {
     eventType: 'SURGE' | 'DROP' | string;
     startDate: string;
     changePct: number;
+    logoUrl?: string | null;
     isScrapped?: boolean;
     scrapped?: boolean;
 };
@@ -27,6 +28,7 @@ export type MyScrapSearchItemDto = {
     eventType: 'SURGE' | 'DROP' | string;
     startDate: string;
     changePct: number;
+    logoUrl?: string | null;
     isScrapped: boolean;
 };
 

--- a/src/features/scrap/hooks/useMyScrapSearch.ts
+++ b/src/features/scrap/hooks/useMyScrapSearch.ts
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 import {
+    fetchMyScraps,
     fetchMyScrapsSearch,
     type MyScrapSearchItemDto,
+    type ScrapEventDto,
 } from '@/features/scrap/api/scrapApi';
 
 type UseMyScrapSearchParams = {
@@ -25,6 +27,19 @@ function isRequestCanceled(error: unknown): boolean {
         return (error as { code?: string }).code === 'ERR_CANCELED';
     }
     return false;
+}
+
+function toSearchItem(item: ScrapEventDto): MyScrapSearchItemDto {
+    return {
+        eventId: item.eventId,
+        stockName: item.stockName,
+        ticker: item.ticker,
+        eventType: item.eventType,
+        startDate: item.startDate,
+        changePct: item.changePct,
+        logoUrl: item.logoUrl ?? null,
+        isScrapped: item.isScrapped ?? item.scrapped ?? true,
+    };
 }
 
 export function useMyScrapSearch({
@@ -60,8 +75,34 @@ export function useMyScrapSearch({
         setLoading(true);
         setError('');
 
+        const keyword = debouncedQuery.trim();
+
+        if (!keyword) {
+            fetchMyScraps()
+                .then((list) => {
+                    if (reqSeq !== requestSeqRef.current) return;
+                    const normalized = list.map(toSearchItem);
+                    setItems(normalized);
+                    setPageInfo({
+                        page: 0,
+                        size,
+                        totalElements: normalized.length,
+                        totalPages: Math.max(1, Math.ceil(normalized.length / size)),
+                    });
+                })
+                .catch((e: unknown) => {
+                    if (reqSeq !== requestSeqRef.current) return;
+                    setError(e instanceof Error ? e.message : '스크랩 목록을 불러오지 못했습니다.');
+                })
+                .finally(() => {
+                    if (reqSeq === requestSeqRef.current) setLoading(false);
+                });
+
+            return () => controller.abort();
+        }
+
         fetchMyScrapsSearch({
-            q: debouncedQuery,
+            q: keyword,
             page,
             size,
             sort,

--- a/src/pages/MyPage/components/MyPageScrapTab.tsx
+++ b/src/pages/MyPage/components/MyPageScrapTab.tsx
@@ -37,7 +37,11 @@ export interface MyPageScrapTabProps {
 
 type ScrapRow = ScrapItem & { id: string; eventId: number };
 
-function ScrapAvatar({ initials, bg }: { initials: string; bg: string }) {
+function ScrapAvatar({ initials, bg, logoUrl }: { initials: string; bg: string; logoUrl?: string | null }) {
+    if (logoUrl) {
+        return <img src={logoUrl} alt="" className="h-7 w-7 shrink-0 rounded-[7px] object-cover" />;
+    }
+
     return (
         <div
             className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[7px] text-[9px] font-black leading-[13.5px] text-white"
@@ -75,7 +79,7 @@ function ScrapSortableEditRow({
             {...listeners}
         >
             <div className="flex min-w-0 flex-1 items-center gap-2.5">
-                <ScrapAvatar initials={row.ini} bg={row.color} />
+                <ScrapAvatar initials={row.ini} bg={row.color} logoUrl={row.logoUrl} />
                 <div className="min-w-0">
                     <div className="text-[12.5px] font-bold leading-[18.75px] text-[#111827]">{row.name}</div>
                     <div className="mypage-scrap-kr text-[10px] leading-[15px] text-[#9ca3af]">
@@ -116,7 +120,7 @@ function ScrapEditRowOverlay({ row }: { row: ScrapRow }) {
     return (
         <div className="mypage-scrap-kr box-border flex w-full min-w-[240px] cursor-grabbing items-center justify-between border-b border-[#eff1f8] bg-white px-[21px] py-3 shadow-sm">
             <div className="flex min-w-0 flex-1 items-center gap-2.5">
-                <ScrapAvatar initials={row.ini} bg={row.color} />
+                <ScrapAvatar initials={row.ini} bg={row.color} logoUrl={row.logoUrl} />
                 <div className="min-w-0">
                     <div className="text-[12.5px] font-bold leading-[18.75px] text-[#111827]">{row.name}</div>
                     <div className="mypage-scrap-kr text-[10px] leading-[15px] text-[#9ca3af]">
@@ -158,6 +162,7 @@ function mapScrapRow(item: MyScrapSearchItemDto, index: number): ScrapRow {
         code: item.ticker ?? '-',
         color: '#014d9d',
         ini: initials,
+        logoUrl: item.logoUrl ?? null,
         date: formatDate(item.startDate),
         eventType: mapEventType(item.eventType),
         chg: `${sign}${change.toFixed(2)}%`,
@@ -317,7 +322,7 @@ export default function MyPageScrapTab({
                                             className="flex h-auto w-full shrink-0 cursor-pointer items-center justify-between border-b border-[#eff1f8] bg-white px-[21px] py-3 text-left transition-colors hover:bg-[#f4f5f7]"
                                         >
                                             <div className="flex min-w-0 flex-1 items-center gap-2.5">
-                                                <ScrapAvatar initials={s.ini} bg={s.color} />
+                                                <ScrapAvatar initials={s.ini} bg={s.color} logoUrl={s.logoUrl} />
                                                 <div className="min-w-0">
                                                     <div className="text-[12.5px] font-bold leading-[18.75px] text-[#111827]">{s.name}</div>
                                                     <div className="mypage-scrap-kr text-[10px] leading-[15px] text-[#9ca3af]">

--- a/src/pages/MyPage/components/myPage.types.ts
+++ b/src/pages/MyPage/components/myPage.types.ts
@@ -4,6 +4,7 @@ export type ScrapItem = {
   name: string;
   code: string;
   color: string;
+  logoUrl?: string | null;
   ini: string;
   date: string;
   eventType: string;


### PR DESCRIPTION
## #️⃣ Issue Number
<!--- ex) #이슈번호, #이슈번호 -->
- Closes #124 
## 📝 변경사항
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 마이페이지 스크랩 탭의 조회 흐름을 API 의미에 맞게 분리
- 기본 목록 조회는 `GET /scraps/my`, 검색어 입력 시 조회는 `GET /scraps/my/search`를 사용하도록 변경, 스크랩 항목 아바타는 `logoUrl`이 있으면 이미지를, 없으면 기존 이니셜 fallback을 표시하도록 수정
### 🎯 핵심 변경 사항 (Key Changes)

- [x] 스크랩 탭 조회 로직 분리: 기본 조회(/scraps/my) vs 검색 조회(/scraps/my/search)
- [x] 스크랩 항목 아바타 렌더링 개선: logoUrl 우선 표시 + 이니셜 fallback 유지

### 🔍 주안점 & 리뷰 포인트
<!--
  (Optional)
  리뷰 시에 유심히 봐주었으면 하는 부분 설명
-->
<!-- 
  - 예: 멀티 모듈 구조에서 의존성 주입 방식이 적절한지 봐주세요.
  - 예: Next.js App Router의 `params` 언래핑(unwrap) 처리가 올바른지 확인 부탁드립니다.
-->
- 검색어가 비어 있을 때는 `/scraps/my`만 호출되는지
- 검색어 입력 시 `/scraps/my/search`로 전환되고 기존 검색/빈 결과 UX가 유지되는지
### 🖼️ 스크린샷 / 테스트 결과 (선택 사항)
<!--
  (Optional)
  작업 결과 만들거나 변경된 화면 스크린샷
  테스트 수행 결과 스크린샷
-->
---
- 기본 목록 조회 시 `/scraps/my` 호출 확인
- 검색 조회 시 `/scraps/my/search` 호출 확인
## 🛠️ PR 유형
- [x] ✨ 새로운 기능 추가
- [x] 🐛 버그 수정
- [x] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## 🧪 영향 범위 및 테스트 (Impact & Tests)
<!--
  (Optional)
  작업에 의해 영향을 받은 모듈/컴포넌트 설명
  수행한 테스트 설명
-->
### **영향을 받는 모듈/컴포넌트:** 
<!--
  (예: `core-api`, `domain-blog`)
-->
- `src/features/scrap/api/scrapApi.ts`
- `src/features/scrap/hooks/useMyScrapSearch.ts`
- `src/pages/MyPage/components/MyPageScrapTab.tsx`
- `src/pages/MyPage/components/myPage.types.ts`
### **테스트 방법:**
- [ ] 단위 테스트 (JUnit/Jest)
- [ ] 통합 테스트
- [x] 수동 API 테스트 (Postman/Swagger)

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 불필요한 로그나 주석을 제거했습니다.
- [x] 관련 이슈를 연결했습니다.
