### PR TITLE
Feat/161 mobile guest UI chart tab fixes

### DIFF
--- a/src/features/event/sharedEventPanelTab.ts
+++ b/src/features/event/sharedEventPanelTab.ts
@@ -1,1 +1,1 @@
-export const sharedEventPanelTab: { value: 'event' | 'memo' } = { value: 'event' };
+export const sharedEventPanelTab: { value: 'overview' | 'event' | 'memo' } = { value: 'event' };

--- a/src/pages/Chart/components/StockDetailMain.tsx
+++ b/src/pages/Chart/components/StockDetailMain.tsx
@@ -348,15 +348,6 @@ export function StockDetailMain({
 
           {mobileTab === "차트" && (
             <>
-              {learningPinData !== null && learningPinData !== undefined && (
-                <div className="scrollbar-hide flex flex-nowrap gap-2 overflow-x-auto border-b border-[#eef2f7] px-4 py-3">
-                  <LearningPin
-                    data={learningPinData}
-                    onClick={() => setMobileTab("오늘의 학습")}
-                  />
-                </div>
-              )}
-
               <div className="shrink-0 bg-white px-4 py-2.5">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <PeriodTabs

--- a/src/pages/StockDetail/index.tsx
+++ b/src/pages/StockDetail/index.tsx
@@ -8,8 +8,10 @@ import { useEventDetail } from '@/features/event/hooks/useEventDetail';
 import { useMemos } from '@/features/event/hooks/useMemos';
 import { useAuth } from '@/features/auth/context/AuthContext';
 import GuestLockPanel from '@/shared/components/common/GuestLockPanel';
+import StockDetailAside from '@/pages/StockDetail/components/StockDetailaside';
 
 const TABS = [
+  { label: '기업 정보', value: 'overview' },
   { label: '이벤트', value: 'event' },
   { label: '메모', value: 'memo' },
 ];
@@ -26,9 +28,9 @@ export default function StockDetailPage() {
   const { event, loading, scrapping, error, scrapError, toggleScrap } = useEventDetail(gatedEventId, isLoggedIn);
   const { memos, save, update, remove } = useMemos(gatedEventId, isLoggedIn);
 
-  const [tab, setTab] = useState<'event' | 'memo'>(sharedEventPanelTab.value);
+  const [tab, setTab] = useState<'overview' | 'event' | 'memo'>(sharedEventPanelTab.value);
   const handleTabChange = (v: string) => {
-    const next = v as 'event' | 'memo';
+    const next = v as 'overview' | 'event' | 'memo';
     sharedEventPanelTab.value = next;
     setTab(next);
   };
@@ -53,17 +55,22 @@ export default function StockDetailPage() {
     return <div className="flex flex-1 items-center justify-center text-sm text-[#9ca3af]">불러오는 중...</div>;
   }
 
-  if (!event && error) {
+  if ((tab === 'event' || tab === 'memo') && !event && error) {
     return <div className="flex flex-1 items-center justify-center text-sm text-[#e03131]">{error}</div>;
   }
 
-  if (!event) {
+  if ((tab === 'event' || tab === 'memo') && !event) {
     return <div className="flex flex-1 items-center justify-center text-sm text-[#9ca3af]">이벤트를 선택해주세요.</div>;
   }
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
       <TabBar tabs={TABS} value={tab} onChange={handleTabChange} />
+      {tab === 'overview' && (
+          <div className="min-h-0 flex-1 overflow-hidden">
+            <StockDetailAside hideHeader />
+          </div>
+      )}
       {tab === 'event' && (
           <EventTab
               event={event}

--- a/src/pages/StockDetail/index.tsx
+++ b/src/pages/StockDetail/index.tsx
@@ -7,8 +7,10 @@ import { useEventDetail } from '@/features/event/hooks/useEventDetail';
 import { useMemos } from '@/features/event/hooks/useMemos';
 import { useAuth } from '@/features/auth/context/AuthContext';
 import GuestLockPanel from '@/shared/components/common/GuestLockPanel';
+import StockDetailAside from '@/pages/StockDetail/components/StockDetailaside';
 
 const TABS = [
+  { label: '기업 정보', value: 'overview' },
   { label: '이벤트', value: 'event' },
   { label: '메모', value: 'memo' },
 ];
@@ -25,8 +27,15 @@ export default function StockDetailPage() {
   const { event, loading, scrapping, error, scrapError, toggleScrap } = useEventDetail(gatedEventId, isLoggedIn);
   const { memos, save, update, remove } = useMemos(gatedEventId, isLoggedIn);
 
-  const requestedTab = searchParams.get('tab') === 'memo' ? 'memo' : 'event';
-  const [tab, setTab] = useState<'event' | 'memo'>(requestedTab);
+  const requestedTabParam = searchParams.get('tab');
+  const requestedTab: 'overview' | 'event' | 'memo' =
+      requestedTabParam === 'memo'
+          ? 'memo'
+          : requestedTabParam === 'overview'
+              ? 'overview'
+              : 'event';
+
+  const [tab, setTab] = useState<'overview' | 'event' | 'memo'>(requestedTab);
 
   useEffect(() => {
     setTab(requestedTab);
@@ -62,7 +71,16 @@ export default function StockDetailPage() {
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
-      <TabBar tabs={TABS} value={tab} onChange={(v) => setTab(v as 'event' | 'memo')} />
+      <TabBar
+          tabs={TABS}
+          value={tab}
+          onChange={(v) => setTab(v as 'overview' | 'event' | 'memo')}
+      />
+      {tab === 'overview' && (
+          <div className="min-h-0 flex-1 overflow-hidden">
+            <StockDetailAside hideHeader />
+          </div>
+      )}
       {tab === 'event' && (
           <EventTab
               event={event}

--- a/src/shared/components/layout/MobileLayout.tsx
+++ b/src/shared/components/layout/MobileLayout.tsx
@@ -61,7 +61,7 @@ export default function MobileLayout({
           <div className="fixed left-0 right-0 top-13.75 bottom-22.25 z-250">
             <GuestLockPanel
               title="알림센터"
-              message={<>로그인 후 관심 종목의<br />오늘의 학습 뉴스 알림을<br />받아보세요.</>}
+              message={<><span className="font-semibold text-[#9ca3af]">로그인</span> 후 관심 종목의<br />오늘의 학습 뉴스 알림을<br />받아보세요.</>}
               onClose={() => setAlertOpen(false)}
             />
           </div>
@@ -71,7 +71,7 @@ export default function MobileLayout({
         <div className="fixed left-0 right-0 top-13.75 bottom-22.25 z-250">
           <GuestLockPanel
             title="마이페이지"
-            message={<>로그인 후 내 예측 기록과<br />학습 메모를 관리해보세요.</>}
+            message={<><span className="font-semibold text-[#9ca3af]">로그인</span> 후 내 예측 기록과<br />학습 메모를 관리해보세요.</>}
             onClose={() => setMyPageOpen(false)}
           />
         </div>


### PR DESCRIPTION
## #️⃣ Issue Number
<!--- ex) #이슈번호, #이슈번호 -->
- Closes #161 
## 📝 변경사항
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 웹 차트에서 이벤트 클릭 시 우측 패널 탭 구성을 기업 정보 / 이벤트 / 메모로 확장
- 기존에는 이벤트 / 메모만 제공되어 기업 정보 확인을 위해 별도 이동이 필요했는데, 같은 패널 내에서 바로 확인 가능하도록 개선

### 🎯 핵심 변경 사항 (Key Changes)

- [ ] 이벤트 패널 탭에 기업 정보 탭 추가 (`StockDetail/index.tsx`)
- [ ] 공유 탭 상태 타입을 `overview | event | memo`로 확장 (`sharedEventPanelTab.ts`)

### 🔍 주안점 & 리뷰 포인트
<!--
  (Optional)
  리뷰 시에 유심히 봐주었으면 하는 부분 설명
-->
<!-- 
  - 예: 멀티 모듈 구조에서 의존성 주입 방식이 적절한지 봐주세요.
  - 예: Next.js App Router의 `params` 언래핑(unwrap) 처리가 올바른지 확인 부탁드립니다.
-->
- `기업 정보` 탭 선택 시 `StockDetailAside`가 정상 렌더링되는지
- `이벤트/메모` 탭에서만 이벤트 데이터 가드(`!event`, `error`)가 동작하도록 분기한 로직이 의도대로 동작하는지
- 기존 이벤트/메모 탭 전환 상태 공유(`sharedEventPanelTab`)에 회귀가 없는지
### 🖼️ 스크린샷 / 테스트 결과 (선택 사항)
<!--
  (Optional)
  작업 결과 만들거나 변경된 화면 스크린샷
  테스트 수행 결과 스크린샷
-->
---

## 🛠️ PR 유형
- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [x] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## 🧪 영향 범위 및 테스트 (Impact & Tests)
<!--
  (Optional)
  작업에 의해 영향을 받은 모듈/컴포넌트 설명
  수행한 테스트 설명
-->
### **영향을 받는 모듈/컴포넌트:** 
<!--
  (예: `core-api`, `domain-blog`)
-->
- `src/pages/StockDetail/index.tsx`
- `src/features/event/sharedEventPanelTab.ts`
- 웹 차트 우측 이벤트 패널( `/chart/:stockCode/event`)
### **테스트 방법:**
- [ ] 단위 테스트 (JUnit/Jest)
- [ ] 통합 테스트
- [x] 수동 API 테스트 (Postman/Swagger)
웹에서 차트 진입 후 이벤트 클릭
우측 패널 탭이 기업 정보 / 이벤트 / 메모 3개로 표시되는지 확인
기업 정보 탭에서 기업 정보 화면 노출 확인
이벤트, 메모 탭 기존 동작 확인
## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 불필요한 로그나 주석을 제거했습니다.
- [x] 관련 이슈를 연결했습니다.
